### PR TITLE
markerpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ src/.wrangler
 
 # Cursor
 .cursor
+
+# opensrc - source code for packages
+opensrc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,3 +112,26 @@ bun run ultracheck   # Fix then verify (fix + check)
 - **Personalization params** — `?to=` and `?from=` rendered in JSX via `usePersonalization`. React auto-escapes; `normalizeName` trims and capitalizes. Avoid rendering raw URL input via `dangerouslySetInnerHTML`.
 - **Deploy script** expects `dist/justfuckingusecloudflare` directory to exist before deploying.
 - **Worker is redundant** — `worker/index.ts` just serves `index.html`, duplicating `not_found_handling: "single-page-application"` in `wrangler.jsonc`.
+
+<!-- opensrc:start -->
+
+## Source Code Reference
+
+Source code for dependencies is available in `opensrc/` for deeper understanding of implementation details.
+
+See `opensrc/sources.json` for the list of available packages and their versions.
+
+Use this source code when you need to understand how a package works internally, not just its types/interface.
+
+### Fetching Additional Source Code
+
+To fetch source code for a package or repository you need to understand, run:
+
+```bash
+npx opensrc <package>           # npm package (e.g., npx opensrc zod)
+npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
+npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
+```
+
+<!-- opensrc:end -->

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,8 @@
     "": {
       "name": "jfuc---just-fucking-use-cloudflare",
       "dependencies": {
-        "lucide-react": "^1.8.0",
+        "@cloudflare/kumo": "^1.18.0",
+        "@phosphor-icons/react": "^2.1.10",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.0",
@@ -15,6 +16,8 @@
         "@cloudflare/vite-plugin": "^1.31.2",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^25.6.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "lefthook": "^2.1.5",
         "tailwindcss": "^4.2.2",
@@ -30,6 +33,12 @@
     "rollup": "^4.59.0",
   },
   "packages": {
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@base-ui/react": ["@base-ui/react@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.6", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
@@ -52,6 +61,8 @@
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
+    "@cloudflare/kumo": ["@cloudflare/kumo@1.18.0", "", { "dependencies": { "@base-ui/react": "^1.2.0", "@shikijs/langs": "^4.0.0", "@shikijs/themes": "^4.0.0", "clsx": "^2.1.1", "motion": "^12.34.1", "react-day-picker": "^9.13.2", "shiki": "^4.0.0", "tailwind-merge": "^3.4.0" }, "peerDependencies": { "@phosphor-icons/react": "^2.1.10", "echarts": "^6.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "zod": "^4.0.0" }, "optionalPeers": ["zod"], "bin": { "kumo": "bin/kumo.js" } }, "sha512-D1OkzYe6rIPe2CqklE+DDt84YB8Q+gV5PH/Hjco8TO1NEHZkaookdl67YU+HHWCBME6TxSwQRzn72hp/cyOrCw=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg=="],
@@ -69,6 +80,8 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260409.1", "", { "os": "win32", "cpu": "x64" }, "sha512-GttFO0+TvE0rJNQbDlxC6kq2Q7uFxoZRo74Z9d/trUrLgA14HEVTTXobYyiWrDZ9Qp2W5KN1CrXQXiko0zE38Q=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
@@ -127,6 +140,14 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -194,6 +215,8 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
+    "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -232,9 +255,27 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@7.1.1", "", {}, "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.12", "", {}, "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA=="],
+
+    "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
 
@@ -268,7 +309,19 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
@@ -278,7 +331,17 @@
 
     "brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
     "citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
@@ -286,9 +349,21 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "echarts": ["echarts@6.0.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.0.0" } }, "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
@@ -304,11 +379,19 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -368,9 +451,19 @@
 
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
-    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "miniflare": ["miniflare@4.20260409.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.4", "workerd": "1.20260409.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-ayl6To4av0YuXsSivGgWLj+Ug8xZ0Qz3sGV8+Ok2LhNVl6m8m5ktEBM3LX9iT9MtLZRJwBlJrKcraNs/DlZQfA=="],
 
@@ -378,9 +471,19 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nypm": ["nypm@0.6.5", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.5", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -396,13 +499,25 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-day-picker": ["react-day-picker@9.14.0", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-router": ["react-router@7.14.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ=="],
 
     "react-router-dom": ["react-router-dom@7.14.0", "", { "dependencies": { "react-router": "7.14.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
@@ -418,11 +533,21 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
+
+    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 
@@ -431,6 +556,8 @@
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -443,6 +570,22 @@
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
@@ -457,6 +600,10 @@
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zrender": ["zrender@6.0.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -476,8 +623,12 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "echarts/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "lefthook install"
   },
   "dependencies": {
-    "lucide-react": "^1.8.0",
+    "@cloudflare/kumo": "^1.18.0",
+    "@phosphor-icons/react": "^2.1.10",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.0"
@@ -25,6 +26,8 @@
     "@cloudflare/vite-plugin": "^1.31.2",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "lefthook": "^2.1.5",
     "tailwindcss": "^4.2.2",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,7 +16,6 @@ const HomePage: React.FC = () => {
   const { from } = usePersonalization();
 
   useEffect(() => {
-    // Console easter egg from original content
     console.log(
       "%c🖕 LISTEN UP, DEVELOPER",
       "font-size: 32px; font-weight: bold; color: #F6821F;"
@@ -34,7 +33,7 @@ const HomePage: React.FC = () => {
   return (
     <>
       <a
-        className="sr-only focus:not-sr-only focus:absolute focus:top-6 focus:left-6 focus:z-50 focus:rounded-full focus:bg-orange-500 focus:px-6 focus:py-3 focus:font-bold focus:font-mono focus:text-black focus:uppercase focus:tracking-tight focus:outline-none"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-6 focus:left-6 focus:z-50 focus:rounded-full focus:bg-jfuc-brand focus:px-6 focus:py-3 focus:font-bold focus:font-mono focus:text-kumo-canvas focus:uppercase focus:tracking-tight focus:outline-none"
         href="#main-content"
       >
         Skip to main content
@@ -57,7 +56,6 @@ const ScrollToTop: React.FC = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    // Scroll to top when pathname changes
     if (pathname) {
       window.scrollTo(0, 0);
     }
@@ -69,7 +67,7 @@ const ScrollToTop: React.FC = () => {
 const App: React.FC = () => (
   <BrowserRouter>
     <ScrollToTop />
-    <div className="min-h-screen selection:bg-orange-500 selection:text-black">
+    <div className="min-h-screen selection:bg-jfuc-brand selection:text-kumo-canvas">
       <Routes>
         <Route element={<HomePage />} path="/" />
         <Route element={<PrivacyPolicy />} path="/privacy-policy" />

--- a/src/components/comparison.tsx
+++ b/src/components/comparison.tsx
@@ -1,133 +1,151 @@
-import { Badge, cn, Surface } from "@cloudflare/kumo";
+import { Badge, LayerCard, Table, Text } from "@cloudflare/kumo";
 import {
-  Brain,
-  CloudLightning,
-  Database,
-  Gauge,
-  GitBranch,
-  Globe,
-  Lightning,
-  Link,
-  Package,
+  BrainIcon,
+  CloudIcon,
+  DatabaseIcon,
+  GlobeIcon,
+  HardDrivesIcon,
+  LightningIcon,
+  LinkIcon,
+  ListBulletsIcon,
+  TreeStructureIcon,
 } from "@phosphor-icons/react";
 import type React from "react";
 
-const cards = [
+const rows = [
   {
-    icon: <Globe className="h-6 w-6" weight="bold" />,
-    title: "CDN",
-    vs: "CloudFront, Akamai, Fastly",
-    desc: "Global anycast CDN with built-in DDoS protection and smart caching. No extra boxes, no multi-vendor dance.",
-    free: "Global CDN included on every plan",
+    icon: <GlobeIcon className="h-5 w-5" weight="bold" />,
+    product: "CDN",
+    replaces: "CloudFront, Akamai, Fastly",
+    desc: "Global anycast CDN with DDoS protection and smart caching.",
+    free: "Included on every plan",
+    variant: "green" as const,
   },
   {
-    icon: <Database className="h-6 w-6" weight="bold" />,
-    title: "D1 Database",
-    vs: "PlanetScale, Supabase, Neon",
-    desc: "Serverless SQLite with read replication. Query at the edge. No connection pooling headaches.",
+    icon: <DatabaseIcon className="h-5 w-5" weight="bold" />,
+    product: "D1 Database",
+    replaces: "PlanetScale, Supabase, Neon",
+    desc: "Serverless SQLite with read replication at the edge.",
     free: "5M reads/day FREE",
+    variant: "orange" as const,
   },
   {
-    icon: <Link className="h-6 w-6" weight="bold" />,
-    title: "Registrar",
-    vs: "GoDaddy scams",
-    desc: "Domains at actual wholesale cost. No renewal traps. Free privacy.",
+    icon: <LinkIcon className="h-5 w-5" weight="bold" />,
+    product: "Registrar",
+    replaces: "GoDaddy, Namecheap",
+    desc: "Domains at wholesale cost. No renewal traps. Free privacy.",
     free: "No bullshit pricing",
+    variant: "blue" as const,
   },
   {
-    icon: <Package className="h-6 w-6" weight="bold" />,
-    title: "R2 Storage",
-    vs: "S3, GCS, Azure Blob",
-    desc: "S3-compatible object storage with zero egress fees. Stop letting AWS rob you blind.",
-    free: "10GB storage FREE · $0 egress FOREVER",
+    icon: <HardDrivesIcon className="h-5 w-5" weight="bold" />,
+    product: "R2 Storage",
+    replaces: "S3, GCS, Azure Blob",
+    desc: "S3-compatible object storage with zero egress fees.",
+    free: "10GB FREE · $0 egress FOREVER",
+    variant: "green" as const,
   },
   {
-    icon: <CloudLightning className="h-6 w-6" weight="bold" />,
-    title: "Queues",
-    vs: "SQS, SNS, RabbitMQ",
-    desc: "Guaranteed message delivery with zero egress fees. Offload work, batch data, and connect Workers seamlessly.",
-    free: "Zero egress fees · At-least-once delivery",
+    icon: <ListBulletsIcon className="h-5 w-5" weight="bold" />,
+    product: "Queues",
+    replaces: "SQS, SNS, RabbitMQ",
+    desc: "Guaranteed delivery with zero egress. Connect Workers seamlessly.",
+    free: "Zero egress fees",
+    variant: "orange" as const,
   },
   {
-    icon: <Gauge className="h-6 w-6" weight="bold" />,
-    title: "Pages",
-    vs: "Vercel, Netlify",
-    desc: "Unlimited bandwidth. Real previews. Git integration. Just works.",
+    icon: <CloudIcon className="h-5 w-5" weight="bold" />,
+    product: "Pages",
+    replaces: "Vercel, Netlify",
+    desc: "Unlimited bandwidth. Real previews. Git integration.",
     free: "Unlimited sites FREE",
+    variant: "blue" as const,
   },
   {
-    icon: <Brain className="h-6 w-6" weight="bold" />,
-    title: "Workers AI",
-    vs: "OpenAI, Replicate",
+    icon: <BrainIcon className="h-5 w-5" weight="bold" />,
+    product: "Workers AI",
+    replaces: "OpenAI, Replicate",
     desc: "Run LLMs at the edge. No infra. No GPUs to manage.",
     free: "10k neurons/day FREE",
+    variant: "orange" as const,
   },
   {
-    icon: <Lightning className="h-6 w-6" weight="bold" />,
-    title: "Workers",
-    vs: "Lambda, Vercel Functions",
-    desc: "V8 isolates with 0ms cold starts. No containers, no VMs, just instant execution at 300+ edge locations.",
+    icon: <LightningIcon className="h-5 w-5" weight="bold" />,
+    product: "Workers",
+    replaces: "Lambda, Vercel Functions",
+    desc: "V8 isolates, 0ms cold starts, 300+ edge locations.",
     free: "100k requests/day FREE",
+    variant: "green" as const,
   },
   {
-    icon: <GitBranch className="h-6 w-6" weight="bold" />,
-    title: "Workflows",
-    vs: "Step Functions, Temporal",
-    desc: "Durable execution for reliable long-running tasks. Auto-resumes on failure. No infrastructure to manage.",
+    icon: <TreeStructureIcon className="h-5 w-5" weight="bold" />,
+    product: "Workflows",
+    replaces: "Step Functions, Temporal",
+    desc: "Durable execution. Auto-resumes on failure.",
     free: "Built into Workers platform",
+    variant: "blue" as const,
   },
 ];
 
 export const Comparison: React.FC = () => (
-  <section className="border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
+  <section
+    className="border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32"
+    id="comparison"
+  >
     <div className="mx-auto max-w-7xl">
-      <h2 className="mb-12 text-center font-anton text-3xl text-kumo-default uppercase tracking-tight md:mb-20 md:text-5xl lg:text-6xl">
+      <h2 className="mb-4 text-center font-anton text-3xl text-kumo-default uppercase tracking-tight md:mb-6 md:text-5xl lg:text-6xl">
         STOP PAYING FOR THIS{" "}
         <span className="text-kumo-brand underline decoration-8 decoration-kumo-brand/20 underline-offset-8">
           BULLSHIT
         </span>
       </h2>
+      <p className="mb-12 text-center font-mono text-kumo-inactive text-sm uppercase tracking-widest md:mb-16">
+        One platform. Zero excuses.
+      </p>
 
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-        {cards.map((card) => {
-          const isCdnCard = card.title === "CDN";
-
-          return (
-            <Surface
-              className={cn(
-                "group rounded-2xl p-6 transition-all duration-300 hover:shadow-[0_0_30px_rgba(246,130,31,0.1)] hover:ring-kumo-brand/50 md:p-8"
-              )}
-              key={card.title}
-            >
-              <div className="mb-6 flex items-start gap-4">
-                <div className="rounded-xl bg-kumo-brand/10 p-3 text-kumo-brand transition-colors group-hover:bg-kumo-brand group-hover:text-kumo-canvas">
-                  {card.icon}
-                </div>
-                <div>
-                  <h3 className="font-anton text-2xl text-kumo-default uppercase tracking-wide transition-colors group-hover:text-kumo-brand">
-                    {card.title}
-                  </h3>
-                  <p className="mt-1 font-mono text-kumo-subtle text-xs uppercase">
-                    vs. {card.vs}
-                  </p>
-                </div>
-              </div>
-              <p
-                className={
-                  isCdnCard
-                    ? "mb-6 min-h-[60px] text-kumo-subtle text-xs leading-snug md:h-16 md:text-sm"
-                    : "mb-6 min-h-[80px] text-kumo-subtle text-sm leading-relaxed md:h-20 md:text-base"
-                }
-              >
-                {card.desc}
-              </p>
-              <div className="border-kumo-line border-t pt-6">
-                <Badge variant="orange">{card.free}</Badge>
-              </div>
-            </Surface>
-          );
-        })}
-      </div>
+      <LayerCard>
+        <LayerCard.Primary className="overflow-x-auto p-0">
+          <Table>
+            <Table.Header>
+              <Table.Row>
+                <Table.Head>Cloudflare Product</Table.Head>
+                <Table.Head>Replaces</Table.Head>
+                <Table.Head className="hidden md:table-cell">
+                  What it does
+                </Table.Head>
+                <Table.Head>Free Tier</Table.Head>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {rows.map((row) => (
+                <Table.Row key={row.product}>
+                  <Table.Cell>
+                    <div className="flex items-center gap-3">
+                      <span className="text-kumo-brand">{row.icon}</span>
+                      <Text bold size="sm">
+                        {row.product}
+                      </Text>
+                    </div>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text color="subtle" size="sm">
+                      {row.replaces}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell className="hidden md:table-cell">
+                    <Text color="subtle" size="sm">
+                      {row.desc}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge variant={row.variant}>{row.free}</Badge>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </LayerCard.Primary>
+      </LayerCard>
     </div>
   </section>
 );

--- a/src/components/comparison.tsx
+++ b/src/components/comparison.tsx
@@ -1,73 +1,76 @@
+import { Badge, cn, Surface } from "@cloudflare/kumo";
 import {
   Brain,
+  CloudLightning,
   Database,
+  Gauge,
   GitBranch,
   Globe,
+  Lightning,
   Link,
   Package,
-  Zap,
-} from "lucide-react";
+} from "@phosphor-icons/react";
 import type React from "react";
 
 const cards = [
   {
-    icon: <Globe className="h-6 w-6" />,
+    icon: <Globe className="h-6 w-6" weight="bold" />,
     title: "CDN",
     vs: "CloudFront, Akamai, Fastly",
     desc: "Global anycast CDN with built-in DDoS protection and smart caching. No extra boxes, no multi-vendor dance.",
     free: "Global CDN included on every plan",
   },
   {
-    icon: <Database className="h-6 w-6" />,
+    icon: <Database className="h-6 w-6" weight="bold" />,
     title: "D1 Database",
     vs: "PlanetScale, Supabase, Neon",
     desc: "Serverless SQLite with read replication. Query at the edge. No connection pooling headaches.",
     free: "5M reads/day FREE",
   },
   {
-    icon: <Link className="h-6 w-6" />,
+    icon: <Link className="h-6 w-6" weight="bold" />,
     title: "Registrar",
     vs: "GoDaddy scams",
     desc: "Domains at actual wholesale cost. No renewal traps. Free privacy.",
     free: "No bullshit pricing",
   },
   {
-    icon: <Package className="h-6 w-6" />,
+    icon: <Package className="h-6 w-6" weight="bold" />,
     title: "R2 Storage",
     vs: "S3, GCS, Azure Blob",
     desc: "S3-compatible object storage with zero egress fees. Stop letting AWS rob you blind.",
-    free: "10GB storage FREE • $0 egress FOREVER",
+    free: "10GB storage FREE · $0 egress FOREVER",
   },
   {
-    icon: <Zap className="h-6 w-6" />,
+    icon: <CloudLightning className="h-6 w-6" weight="bold" />,
     title: "Queues",
     vs: "SQS, SNS, RabbitMQ",
     desc: "Guaranteed message delivery with zero egress fees. Offload work, batch data, and connect Workers seamlessly.",
-    free: "Zero egress fees • At-least-once delivery",
+    free: "Zero egress fees · At-least-once delivery",
   },
   {
-    icon: <Globe className="h-6 w-6" />,
+    icon: <Gauge className="h-6 w-6" weight="bold" />,
     title: "Pages",
     vs: "Vercel, Netlify",
     desc: "Unlimited bandwidth. Real previews. Git integration. Just works.",
     free: "Unlimited sites FREE",
   },
   {
-    icon: <Brain className="h-6 w-6" />,
+    icon: <Brain className="h-6 w-6" weight="bold" />,
     title: "Workers AI",
     vs: "OpenAI, Replicate",
     desc: "Run LLMs at the edge. No infra. No GPUs to manage.",
     free: "10k neurons/day FREE",
   },
   {
-    icon: <Zap className="h-6 w-6" />,
+    icon: <Lightning className="h-6 w-6" weight="bold" />,
     title: "Workers",
     vs: "Lambda, Vercel Functions",
     desc: "V8 isolates with 0ms cold starts. No containers, no VMs, just instant execution at 300+ edge locations.",
     free: "100k requests/day FREE",
   },
   {
-    icon: <GitBranch className="h-6 w-6" />,
+    icon: <GitBranch className="h-6 w-6" weight="bold" />,
     title: "Workflows",
     vs: "Step Functions, Temporal",
     desc: "Durable execution for reliable long-running tasks. Auto-resumes on failure. No infrastructure to manage.",
@@ -76,11 +79,11 @@ const cards = [
 ];
 
 export const Comparison: React.FC = () => (
-  <section className="border-neutral-800 border-b bg-neutral-950 px-6 py-24 md:py-32">
+  <section className="border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
     <div className="mx-auto max-w-7xl">
-      <h2 className="mb-12 text-center font-anton text-3xl uppercase tracking-tight md:mb-20 md:text-5xl lg:text-6xl">
+      <h2 className="mb-12 text-center font-anton text-3xl text-kumo-default uppercase tracking-tight md:mb-20 md:text-5xl lg:text-6xl">
         STOP PAYING FOR THIS{" "}
-        <span className="text-orange-500 underline decoration-8 decoration-orange-500/20 underline-offset-8">
+        <span className="text-kumo-brand underline decoration-8 decoration-kumo-brand/20 underline-offset-8">
           BULLSHIT
         </span>
       </h2>
@@ -90,19 +93,21 @@ export const Comparison: React.FC = () => (
           const isCdnCard = card.title === "CDN";
 
           return (
-            <article
-              className="group rounded-2xl border border-neutral-800 bg-neutral-900 p-6 transition-all duration-300 hover:border-orange-500/50 hover:shadow-[0_0_30px_rgba(246,130,31,0.1)] md:p-8"
+            <Surface
+              className={cn(
+                "group rounded-2xl p-6 transition-all duration-300 hover:shadow-[0_0_30px_rgba(246,130,31,0.1)] hover:ring-kumo-brand/50 md:p-8"
+              )}
               key={card.title}
             >
               <div className="mb-6 flex items-start gap-4">
-                <div className="rounded-xl bg-orange-500/10 p-3 text-orange-500 transition-colors group-hover:bg-orange-500 group-hover:text-black">
+                <div className="rounded-xl bg-kumo-brand/10 p-3 text-kumo-brand transition-colors group-hover:bg-kumo-brand group-hover:text-kumo-canvas">
                   {card.icon}
                 </div>
                 <div>
-                  <h3 className="font-anton text-2xl uppercase tracking-wide transition-colors group-hover:text-orange-400">
+                  <h3 className="font-anton text-2xl text-kumo-default uppercase tracking-wide transition-colors group-hover:text-kumo-brand">
                     {card.title}
                   </h3>
-                  <p className="mt-1 font-mono text-neutral-500 text-xs uppercase">
+                  <p className="mt-1 font-mono text-kumo-subtle text-xs uppercase">
                     vs. {card.vs}
                   </p>
                 </div>
@@ -110,18 +115,16 @@ export const Comparison: React.FC = () => (
               <p
                 className={
                   isCdnCard
-                    ? "mb-6 min-h-[60px] text-neutral-400 text-xs leading-snug md:h-16 md:text-sm"
-                    : "mb-6 min-h-[80px] text-neutral-400 text-sm leading-relaxed md:h-20 md:text-base"
+                    ? "mb-6 min-h-[60px] text-kumo-subtle text-xs leading-snug md:h-16 md:text-sm"
+                    : "mb-6 min-h-[80px] text-kumo-subtle text-sm leading-relaxed md:h-20 md:text-base"
                 }
               >
                 {card.desc}
               </p>
-              <div className="border-neutral-800 border-t pt-6">
-                <span className="rounded-full border border-orange-500/20 bg-orange-500/5 px-3 py-1 font-bold font-mono text-orange-500 text-xs uppercase tracking-tighter">
-                  {card.free}
-                </span>
+              <div className="border-kumo-line border-t pt-6">
+                <Badge variant="orange">{card.free}</Badge>
               </div>
-            </article>
+            </Surface>
           );
         })}
       </div>

--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -1,9 +1,18 @@
-import { ArrowRight } from "@phosphor-icons/react";
+import { Button } from "@cloudflare/kumo";
+import { ArrowRightIcon, BookOpenIcon } from "@phosphor-icons/react";
 import type React from "react";
 
 export const CTA: React.FC = () => (
-  <section className="border-kumo-line border-b bg-gradient-to-b from-kumo-elevated to-kumo-canvas px-6 py-24 md:py-32">
-    <div className="mx-auto max-w-4xl text-center">
+  <section className="relative overflow-hidden border-kumo-line border-b bg-gradient-to-b from-kumo-elevated to-kumo-canvas px-6 py-24 md:py-32">
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0"
+      style={{
+        background:
+          "radial-gradient(ellipse 70% 50% at 50% 50%, rgba(246,130,31,0.10) 0%, transparent 70%)",
+      }}
+    />
+    <div className="relative mx-auto max-w-4xl text-center">
       <h2 className="mb-8 font-anton text-4xl text-kumo-default uppercase tracking-tight md:text-6xl lg:text-7xl">
         STOP <span className="text-kumo-brand">FUCKING</span> AROUND.
         <br />
@@ -14,29 +23,34 @@ export const CTA: React.FC = () => (
         shipping. Sign up and never think about egress fees again.
       </p>
       <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-        <a
-          aria-label="Get started with Cloudflare for free"
-          className="group brand-glow inline-flex w-full items-center justify-center gap-3 rounded-full border-2 border-kumo-brand bg-kumo-brand px-10 py-5 font-bold font-mono text-kumo-canvas uppercase tracking-tight transition-all hover:bg-kumo-brand-hover focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-4 active:opacity-80 sm:w-auto"
-          href="https://dash.cloudflare.com/sign-up"
-          rel="noopener noreferrer"
-          target="_blank"
+        <Button
+          icon={ArrowRightIcon}
+          onClick={() =>
+            window.open(
+              "https://dash.cloudflare.com/sign-up",
+              "_blank",
+              "noopener,noreferrer"
+            )
+          }
+          size="lg"
+          variant="primary"
         >
           FUCKING DO IT ALREADY
-          <ArrowRight
-            aria-hidden="true"
-            className="h-5 w-5 transition-transform group-hover:translate-x-1"
-            weight="bold"
-          />
-        </a>
-        <a
-          aria-label="Read Cloudflare developer documentation"
-          className="brand-glow-focus inline-flex w-full items-center justify-center rounded-full border-2 border-kumo-line bg-transparent px-8 py-5 font-bold font-mono text-kumo-default uppercase tracking-tight transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-4 sm:w-auto"
-          href="https://developers.cloudflare.com"
-          rel="noopener noreferrer"
-          target="_blank"
+        </Button>
+        <Button
+          icon={BookOpenIcon}
+          onClick={() =>
+            window.open(
+              "https://developers.cloudflare.com",
+              "_blank",
+              "noopener,noreferrer"
+            )
+          }
+          size="lg"
+          variant="secondary"
         >
           FINE, READ THE DOCS FIRST
-        </a>
+        </Button>
       </div>
     </div>
   </section>

--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -1,22 +1,22 @@
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@phosphor-icons/react";
 import type React from "react";
 
 export const CTA: React.FC = () => (
-  <section className="border-neutral-800 border-b bg-gradient-to-b from-neutral-900 to-neutral-950 px-6 py-24 md:py-32">
+  <section className="border-kumo-line border-b bg-gradient-to-b from-kumo-elevated to-kumo-canvas px-6 py-24 md:py-32">
     <div className="mx-auto max-w-4xl text-center">
-      <h2 className="mb-8 font-anton text-4xl text-white uppercase tracking-tight md:text-6xl lg:text-7xl">
-        STOP <span className="text-orange-500">FUCKING</span> AROUND.
+      <h2 className="mb-8 font-anton text-4xl text-kumo-default uppercase tracking-tight md:text-6xl lg:text-7xl">
+        STOP <span className="text-kumo-brand">FUCKING</span> AROUND.
         <br />
-        JUST <span className="text-orange-500">USE CLOUDFLARE</span>.
+        JUST <span className="text-kumo-brand">USE CLOUDFLARE</span>.
       </h2>
-      <p className="mb-12 font-mono text-lg text-neutral-400 md:text-xl">
+      <p className="mb-12 font-mono text-kumo-subtle text-lg md:text-xl">
         Your infrastructure is not a personality trait. Stop suffering. Start
         shipping. Sign up and never think about egress fees again.
       </p>
       <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
         <a
           aria-label="Get started with Cloudflare for free"
-          className="group inline-flex w-full items-center justify-center gap-3 rounded-full border-2 border-orange-500 bg-orange-500 px-10 py-5 font-bold font-mono text-black uppercase tracking-tight transition-all hover:bg-orange-400 hover:shadow-[0_0_40px_rgba(246,130,31,0.4)] focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-4 active:bg-orange-600 sm:w-auto"
+          className="group brand-glow inline-flex w-full items-center justify-center gap-3 rounded-full border-2 border-kumo-brand bg-kumo-brand px-10 py-5 font-bold font-mono text-kumo-canvas uppercase tracking-tight transition-all hover:bg-kumo-brand-hover focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-4 active:opacity-80 sm:w-auto"
           href="https://dash.cloudflare.com/sign-up"
           rel="noopener noreferrer"
           target="_blank"
@@ -25,11 +25,12 @@ export const CTA: React.FC = () => (
           <ArrowRight
             aria-hidden="true"
             className="h-5 w-5 transition-transform group-hover:translate-x-1"
+            weight="bold"
           />
         </a>
         <a
           aria-label="Read Cloudflare developer documentation"
-          className="inline-flex w-full items-center justify-center rounded-full border-2 border-neutral-700 bg-transparent px-8 py-5 font-bold font-mono text-white uppercase tracking-tight transition-all hover:border-orange-500 hover:text-orange-500 hover:shadow-[0_0_20px_rgba(246,130,31,0.2)] focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-4 active:border-orange-600 active:text-orange-600 sm:w-auto"
+          className="brand-glow-focus inline-flex w-full items-center justify-center rounded-full border-2 border-kumo-line bg-transparent px-8 py-5 font-bold font-mono text-kumo-default uppercase tracking-tight transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-4 sm:w-auto"
           href="https://developers.cloudflare.com"
           rel="noopener noreferrer"
           target="_blank"

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -1,48 +1,120 @@
-import { Surface } from "@cloudflare/kumo";
-import { CheckCircle } from "@phosphor-icons/react";
+import { Badge, Tabs, Text } from "@cloudflare/kumo";
 import type React from "react";
+import { useState } from "react";
 
-const features = [
-  "Zero cold starts. Ever.",
-  "300+ edge locations worldwide",
-  "Free tier that's actually usable",
-  "No egress fees on R2 storage",
-  "SQLite at the edge with D1",
-  "Unlimited bandwidth on Pages",
-  "Workers AI at the edge",
-  "Message queues with zero egress fees",
-  "Durable workflows that auto-resume",
-  "Real preview deployments",
-  "Git integration that just works",
-  "Wholesale domain pricing",
-  "Free SSL certificates",
-  "DDoS protection included",
-  "Security, performance & Zero Trust",
+type Tab = "compute" | "storage" | "network" | "developer";
+
+const tabConfig: { value: Tab; label: string }[] = [
+  { value: "compute", label: "Compute" },
+  { value: "storage", label: "Storage" },
+  { value: "network", label: "Network" },
+  { value: "developer", label: "Developer" },
 ];
 
-export const Features: React.FC = () => (
-  <section className="border-kumo-line border-b bg-kumo-elevated px-6 py-24 md:py-32">
-    <div className="mx-auto max-w-7xl">
-      <h2 className="mb-4 text-center font-anton text-3xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
-        One platform. Everything you need.
-      </h2>
+const features: Record<Tab, { label: string; detail: string }[]> = {
+  compute: [
+    { label: "Workers", detail: "0ms cold starts at 300+ edge locations" },
+    { label: "Pages", detail: "Unlimited bandwidth, real preview deploys" },
+    {
+      label: "Workflows",
+      detail: "Durable execution that auto-resumes on failure",
+    },
+    { label: "Workers AI", detail: "Run LLMs at the edge — no GPUs, no infra" },
+    {
+      label: "Durable Objects",
+      detail: "Stateful coordination with global consistency",
+    },
+  ],
+  storage: [
+    {
+      label: "R2",
+      detail: "S3-compatible storage — zero egress fees, forever",
+    },
+    { label: "D1", detail: "SQLite at the edge with read replication" },
+    {
+      label: "KV",
+      detail: "Global key-value store with sub-millisecond reads",
+    },
+    { label: "Queues", detail: "At-least-once delivery, zero egress" },
+    {
+      label: "Vectorize",
+      detail: "Vector database for AI embeddings at the edge",
+    },
+  ],
+  network: [
+    { label: "CDN", detail: "Global anycast with smart caching built in" },
+    { label: "DDoS Protection", detail: "Included on every plan, always on" },
+    {
+      label: "Free SSL",
+      detail: "Automatic certificate provisioning and renewal",
+    },
+    { label: "Zero Trust", detail: "Security without the VPN tax" },
+    {
+      label: "Load Balancing",
+      detail: "Global traffic management across origins",
+    },
+  ],
+  developer: [
+    {
+      label: "Git Integration",
+      detail: "Connects to your repo and just works",
+    },
+    {
+      label: "Preview Deployments",
+      detail: "Real previews per branch, not fake ones",
+    },
+    { label: "One Dashboard", detail: "Everything in one place, one login" },
+    { label: "One Bill", detail: "Not seventeen separate invoices" },
+    {
+      label: "Wholesale Domains",
+      detail: "Registrar pricing with no renewal traps",
+    },
+  ],
+};
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {features.map((feature) => (
-          <Surface
-            className="flex items-center gap-3 rounded-xl p-4 transition-all hover:ring-kumo-brand/50"
-            key={feature}
-          >
-            <CheckCircle
-              className="h-5 w-5 shrink-0 text-kumo-brand"
-              weight="fill"
-            />
-            <span className="font-mono text-kumo-subtle text-sm">
-              {feature}
-            </span>
-          </Surface>
-        ))}
+export const Features: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<Tab>("compute");
+
+  return (
+    <section className="relative overflow-hidden border-kumo-line border-b bg-kumo-elevated px-6 py-24 md:py-32">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-64"
+        style={{
+          background:
+            "radial-gradient(ellipse 60% 100% at 50% 100%, rgba(246,130,31,0.07) 0%, transparent 70%)",
+        }}
+      />
+      <div className="relative mx-auto max-w-4xl">
+        <h2 className="mb-4 text-center font-anton text-3xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
+          One platform. <span className="text-kumo-brand">Everything</span> you
+          need.
+        </h2>
+        <p className="mb-10 text-center font-mono text-kumo-inactive text-sm uppercase tracking-widest">
+          One bill. One dashboard. Zero excuses.
+        </p>
+
+        <Tabs
+          onValueChange={(v) => setActiveTab(v as Tab)}
+          tabs={tabConfig}
+          value={activeTab}
+          variant="underline"
+        />
+
+        <div className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {features[activeTab].map((f) => (
+            <div
+              className="flex flex-col gap-1 rounded-xl border border-kumo-line bg-kumo-canvas p-4"
+              key={f.label}
+            >
+              <Badge variant="orange">{f.label}</Badge>
+              <Text color="subtle" size="sm">
+                {f.detail}
+              </Text>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -1,4 +1,5 @@
-import { CheckCircle2 } from "lucide-react";
+import { Surface } from "@cloudflare/kumo";
+import { CheckCircle } from "@phosphor-icons/react";
 import type React from "react";
 
 const features = [
@@ -20,23 +21,26 @@ const features = [
 ];
 
 export const Features: React.FC = () => (
-  <section className="border-neutral-800 border-b bg-neutral-900 px-6 py-24 md:py-32">
+  <section className="border-kumo-line border-b bg-kumo-elevated px-6 py-24 md:py-32">
     <div className="mx-auto max-w-7xl">
-      <h2 className="mb-4 text-center font-anton text-3xl text-white uppercase tracking-tight md:text-5xl lg:text-6xl">
+      <h2 className="mb-4 text-center font-anton text-3xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
         One platform. Everything you need.
       </h2>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         {features.map((feature) => (
-          <div
-            className="flex items-center gap-3 rounded-xl border border-neutral-800 bg-neutral-950 p-4 transition-all hover:border-orange-500/50 hover:bg-neutral-900"
+          <Surface
+            className="flex items-center gap-3 rounded-xl p-4 transition-all hover:ring-kumo-brand/50"
             key={feature}
           >
-            <CheckCircle2 className="h-5 w-5 flex-shrink-0 text-orange-500" />
-            <span className="font-mono text-neutral-300 text-sm">
+            <CheckCircle
+              className="h-5 w-5 shrink-0 text-kumo-brand"
+              weight="fill"
+            />
+            <span className="font-mono text-kumo-subtle text-sm">
               {feature}
             </span>
-          </div>
+          </Surface>
         ))}
       </div>
     </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,3 +1,4 @@
+import { Link, Text } from "@cloudflare/kumo";
 import type React from "react";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -6,151 +7,148 @@ export const Footer: React.FC = () => (
     <div className="mx-auto max-w-7xl">
       <div className="flex flex-col items-center justify-between gap-8 md:flex-row md:items-start">
         <div className="text-center md:text-left">
-          <p className="font-anton text-kumo-default text-xl uppercase tracking-tight">
+          <Text bold size="base">
             Just Fucking Use Cloudflare
-          </p>
-          <p className="mt-2 font-mono text-kumo-subtle text-sm">
+          </Text>
+          <Text color="subtle" size="sm">
             Stop fucking around. Start fucking building.
-          </p>
+          </Text>
         </div>
-        <div className="flex flex-wrap items-center justify-center gap-3 md:justify-end">
-          <a
-            aria-label="Sign up for Cloudflare"
-            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
+        <div className="flex flex-wrap items-center justify-center gap-4 md:justify-end">
+          <Link
             href="https://dash.cloudflare.com/sign-up"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Sign Up
-          </a>
-          <a
-            aria-label="Cloudflare Developer Documentation"
-            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
+            Sign Up <Link.ExternalIcon />
+          </Link>
+          <Link
             href="https://developers.cloudflare.com"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Docs
-          </a>
-          <a
-            aria-label="Cloudflare Blog"
-            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
+            Docs <Link.ExternalIcon />
+          </Link>
+          <Link
             href="https://blog.cloudflare.com"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Blog
-          </a>
-          <a
-            aria-label="Cloudflare Community"
-            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
+            Blog <Link.ExternalIcon />
+          </Link>
+          <Link
             href="https://community.cloudflare.com"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Community
-          </a>
+            Community <Link.ExternalIcon />
+          </Link>
         </div>
       </div>
+
       <div className="mt-8 border-kumo-line border-t pt-8 text-center">
-        <p className="font-mono text-kumo-inactive text-xs">
-          <RouterLink
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            to="/privacy-policy"
-          >
+        <Text color="subtle" size="sm">
+          <Link render={<RouterLink to="/privacy-policy" />} variant="inline">
             Privacy Policy
-          </RouterLink>
-        </p>
-        <p className="mt-4 font-mono text-kumo-inactive text-xs">
-          Not affiliated with Cloudflare. Just someone who loves their products.
-        </p>
-        <p className="mt-2 font-mono text-kumo-inactive text-xs">
-          Inspired by{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://justfuckingusehtml.com"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            justfuckingusehtml.com
-          </a>
-          ,{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://justfuckingusetailwind.com"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            justfuckingusetailwind.com
-          </a>
-          ,{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://justfuckingusereact.com"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            justfuckingusereact.com
-          </a>{" "}
-          and the{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://justfuckinguse.com"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            justfuckinguse.com
-          </a>{" "}
-          ecosystem.
-        </p>
-        <p className="mt-2 font-mono text-kumo-inactive text-xs">
-          Made by:{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://mynameistito.com"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            mynameistito
-          </a>{" "}
-          (
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://buymeacoffee.com/mynameistito"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Buy Me a Coffee
-          </a>
-          ,{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://discord.com/users/611746802122620937"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Discord
-          </a>
-          ,{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://github.com/mynameistito/justfuckingusecloudflare"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            GitHub
-          </a>
-          ,{" "}
-          <a
-            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
-            href="https://x.com/mynameistito"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            X
-          </a>
-          )
-        </p>
+          </Link>
+        </Text>
+        <div className="mt-3">
+          <Text color="subtle" size="sm">
+            Not affiliated with Cloudflare. Just someone who loves their
+            products.
+          </Text>
+        </div>
+        <div className="mt-2">
+          <Text color="subtle" size="sm">
+            Inspired by{" "}
+            <Link
+              href="https://justfuckingusehtml.com"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              justfuckingusehtml.com
+            </Link>
+            ,{" "}
+            <Link
+              href="https://justfuckingusetailwind.com"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              justfuckingusetailwind.com
+            </Link>
+            ,{" "}
+            <Link
+              href="https://justfuckingusereact.com"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              justfuckingusereact.com
+            </Link>{" "}
+            and the{" "}
+            <Link
+              href="https://justfuckinguse.com"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              justfuckinguse.com
+            </Link>{" "}
+            ecosystem.
+          </Text>
+        </div>
+        <div className="mt-2">
+          <Text color="subtle" size="sm">
+            Made by:{" "}
+            <Link
+              href="https://mynameistito.com"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              mynameistito
+            </Link>{" "}
+            (
+            <Link
+              href="https://buymeacoffee.com/mynameistito"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              Buy Me a Coffee
+            </Link>
+            ,{" "}
+            <Link
+              href="https://discord.com/users/611746802122620937"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              Discord
+            </Link>
+            ,{" "}
+            <Link
+              href="https://github.com/mynameistito/justfuckingusecloudflare"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              GitHub
+            </Link>
+            ,{" "}
+            <Link
+              href="https://x.com/mynameistito"
+              rel="noopener noreferrer"
+              target="_blank"
+              variant="inline"
+            >
+              X
+            </Link>
+            )
+          </Text>
+        </div>
       </div>
     </div>
   </footer>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,22 +1,22 @@
 import type React from "react";
-import { Link } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
 export const Footer: React.FC = () => (
-  <footer className="border-neutral-800 border-t bg-neutral-950 px-6 py-12">
+  <footer className="border-kumo-line border-t bg-kumo-canvas px-6 py-12">
     <div className="mx-auto max-w-7xl">
       <div className="flex flex-col items-center justify-between gap-8 md:flex-row md:items-start">
         <div className="text-center md:text-left">
-          <p className="font-anton text-white text-xl uppercase tracking-tight">
+          <p className="font-anton text-kumo-default text-xl uppercase tracking-tight">
             Just Fucking Use Cloudflare
           </p>
-          <p className="mt-2 font-mono text-neutral-500 text-sm">
+          <p className="mt-2 font-mono text-kumo-subtle text-sm">
             Stop fucking around. Start fucking building.
           </p>
         </div>
         <div className="flex flex-wrap items-center justify-center gap-3 md:justify-end">
           <a
             aria-label="Sign up for Cloudflare"
-            className="rounded-full border border-neutral-700 bg-transparent px-4 py-2 font-mono text-neutral-400 text-sm transition-all hover:border-orange-500 hover:text-orange-500 focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-2"
+            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
             href="https://dash.cloudflare.com/sign-up"
             rel="noopener noreferrer"
             target="_blank"
@@ -25,7 +25,7 @@ export const Footer: React.FC = () => (
           </a>
           <a
             aria-label="Cloudflare Developer Documentation"
-            className="rounded-full border border-neutral-700 bg-transparent px-4 py-2 font-mono text-neutral-400 text-sm transition-all hover:border-orange-500 hover:text-orange-500 focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-2"
+            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
             href="https://developers.cloudflare.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -34,7 +34,7 @@ export const Footer: React.FC = () => (
           </a>
           <a
             aria-label="Cloudflare Blog"
-            className="rounded-full border border-neutral-700 bg-transparent px-4 py-2 font-mono text-neutral-400 text-sm transition-all hover:border-orange-500 hover:text-orange-500 focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-2"
+            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
             href="https://blog.cloudflare.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -43,7 +43,7 @@ export const Footer: React.FC = () => (
           </a>
           <a
             aria-label="Cloudflare Community"
-            className="rounded-full border border-neutral-700 bg-transparent px-4 py-2 font-mono text-neutral-400 text-sm transition-all hover:border-orange-500 hover:text-orange-500 focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-2"
+            className="rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
             href="https://community.cloudflare.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -52,22 +52,22 @@ export const Footer: React.FC = () => (
           </a>
         </div>
       </div>
-      <div className="mt-8 border-neutral-800 border-t pt-8 text-center">
-        <p className="font-mono text-neutral-600 text-xs">
-          <Link
-            className="text-orange-500 transition-colors hover:text-orange-400"
+      <div className="mt-8 border-kumo-line border-t pt-8 text-center">
+        <p className="font-mono text-kumo-inactive text-xs">
+          <RouterLink
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             to="/privacy-policy"
           >
             Privacy Policy
-          </Link>
+          </RouterLink>
         </p>
-        <p className="mt-4 font-mono text-neutral-600 text-xs">
+        <p className="mt-4 font-mono text-kumo-inactive text-xs">
           Not affiliated with Cloudflare. Just someone who loves their products.
         </p>
-        <p className="mt-2 font-mono text-neutral-600 text-xs">
+        <p className="mt-2 font-mono text-kumo-inactive text-xs">
           Inspired by{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://justfuckingusehtml.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -76,7 +76,7 @@ export const Footer: React.FC = () => (
           </a>
           ,{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://justfuckingusetailwind.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -85,7 +85,7 @@ export const Footer: React.FC = () => (
           </a>
           ,{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://justfuckingusereact.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -94,7 +94,7 @@ export const Footer: React.FC = () => (
           </a>{" "}
           and the{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://justfuckinguse.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -103,10 +103,10 @@ export const Footer: React.FC = () => (
           </a>{" "}
           ecosystem.
         </p>
-        <p className="mt-2 font-mono text-neutral-600 text-xs">
+        <p className="mt-2 font-mono text-kumo-inactive text-xs">
           Made by:{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://mynameistito.com"
             rel="noopener noreferrer"
             target="_blank"
@@ -115,7 +115,7 @@ export const Footer: React.FC = () => (
           </a>{" "}
           (
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://buymeacoffee.com/mynameistito"
             rel="noopener noreferrer"
             target="_blank"
@@ -124,7 +124,7 @@ export const Footer: React.FC = () => (
           </a>
           ,{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://discord.com/users/611746802122620937"
             rel="noopener noreferrer"
             target="_blank"
@@ -133,7 +133,7 @@ export const Footer: React.FC = () => (
           </a>
           ,{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://github.com/mynameistito/justfuckingusecloudflare"
             rel="noopener noreferrer"
             target="_blank"
@@ -142,7 +142,7 @@ export const Footer: React.FC = () => (
           </a>
           ,{" "}
           <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
+            className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
             href="https://x.com/mynameistito"
             rel="noopener noreferrer"
             target="_blank"

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,13 +1,38 @@
-import { cn } from "@cloudflare/kumo";
+import { Button } from "@cloudflare/kumo";
+import { CaretDownIcon } from "@phosphor-icons/react";
 import type React from "react";
 import { usePersonalization } from "../hooks/use-personalization";
 
 export const Hero: React.FC = () => {
   const { to, from } = usePersonalization();
 
+  const scrollToContent = () => {
+    const el = document.getElementById("comparison");
+    el?.scrollIntoView({ behavior: "smooth" });
+  };
+
   return (
     <section className="relative min-h-screen overflow-hidden border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
-      <div className="mx-auto max-w-7xl text-center">
+      {/* Orange radial glow */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 60% at 50% 40%, rgba(246,130,31,0.12) 0%, transparent 70%)",
+        }}
+      />
+      {/* Subtle grid */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(246,130,31,0.8) 1px, transparent 1px), linear-gradient(90deg, rgba(246,130,31,0.8) 1px, transparent 1px)",
+          backgroundSize: "80px 80px",
+        }}
+      />
+      <div className="relative mx-auto max-w-7xl text-center">
         {from && (
           <p className="mb-6 font-mono text-kumo-default text-lg md:text-xl">
             Hey there, if{" "}
@@ -28,35 +53,23 @@ export const Hero: React.FC = () => {
             {to ? `${to.toUpperCase()}` : "YOU DEGENERATE"}
           </span>
         </h1>
-        <p
-          className={cn(
-            "mx-auto mb-8 max-w-2xl font-mono text-base text-kumo-subtle md:text-lg lg:text-xl"
-          )}
-        >
+        <p className="mx-auto mb-10 max-w-2xl font-mono text-base text-kumo-subtle md:text-lg lg:text-xl">
           Stop paying{" "}
           <strong className="text-kumo-brand">SEVENTEEN DIFFERENT BILLS</strong>{" "}
           for your shitty todo app. Stop pretending you're an infra genius when
           you're just{" "}
           <strong className="text-kumo-brand">bleeding money</strong>.
         </p>
-      </div>
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce">
-        <svg
-          aria-label="Scroll down"
-          className="h-8 w-8 text-kumo-brand md:h-10 md:w-10"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>Scroll down</title>
-          <path
-            d="M19 14l-7 7m0 0l-7-7m7 7V3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-          />
-        </svg>
+        <div className="flex justify-center">
+          <Button
+            icon={CaretDownIcon}
+            onClick={scrollToContent}
+            size="lg"
+            variant="primary"
+          >
+            SHOW ME THE RECEIPTS
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@cloudflare/kumo";
 import type React from "react";
 import { usePersonalization } from "../hooks/use-personalization";
 
@@ -5,21 +6,21 @@ export const Hero: React.FC = () => {
   const { to, from } = usePersonalization();
 
   return (
-    <section className="relative min-h-screen overflow-hidden border-neutral-800 border-b bg-linear-to-b from-neutral-950 to-neutral-900 px-6 py-24 md:py-32">
+    <section className="relative min-h-screen overflow-hidden border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
       <div className="mx-auto max-w-7xl text-center">
         {from && (
-          <p className="mb-6 font-mono text-lg text-neutral-300 md:text-xl">
+          <p className="mb-6 font-mono text-kumo-default text-lg md:text-xl">
             Hey there, if{" "}
-            <span className="font-bold text-orange-500">{from}</span> sent you
+            <span className="font-bold text-kumo-brand">{from}</span> sent you
             this link, you need to:{" "}
           </p>
         )}
-        <p className="mb-4 font-mono text-2xl text-orange-500 uppercase tracking-[0.4em] md:text-3xl lg:text-4xl">
+        <p className="mb-4 font-mono text-2xl text-kumo-brand uppercase tracking-[0.4em] md:text-3xl lg:text-4xl">
           JUST
         </p>
-        <h1 className="mb-6 font-anton text-5xl text-white uppercase tracking-tight md:text-7xl lg:text-8xl xl:text-9xl">
+        <h1 className="mb-6 font-anton text-5xl text-kumo-default uppercase tracking-tight md:text-7xl lg:text-8xl xl:text-9xl">
           <span className="block">FUCKING</span>
-          <span className="block text-orange-500 underline decoration-8 decoration-orange-500/20 underline-offset-8">
+          <span className="block text-kumo-brand underline decoration-8 decoration-kumo-brand/20 underline-offset-8">
             USE
           </span>
           <span className="block">CLOUDFLARE</span>
@@ -27,18 +28,22 @@ export const Hero: React.FC = () => {
             {to ? `${to.toUpperCase()}` : "YOU DEGENERATE"}
           </span>
         </h1>
-        <p className="mx-auto mb-8 max-w-2xl font-mono text-base text-neutral-400 md:text-lg lg:text-xl">
+        <p
+          className={cn(
+            "mx-auto mb-8 max-w-2xl font-mono text-base text-kumo-subtle md:text-lg lg:text-xl"
+          )}
+        >
           Stop paying{" "}
-          <strong className="text-orange-500">SEVENTEEN DIFFERENT BILLS</strong>{" "}
+          <strong className="text-kumo-brand">SEVENTEEN DIFFERENT BILLS</strong>{" "}
           for your shitty todo app. Stop pretending you're an infra genius when
           you're just{" "}
-          <strong className="text-orange-500">bleeding money</strong>.
+          <strong className="text-kumo-brand">bleeding money</strong>.
         </p>
       </div>
       <div className="absolute bottom-8 left-1/2 -translate-x-1/2 animate-bounce">
         <svg
           aria-label="Scroll down"
-          className="h-8 w-8 text-orange-500 md:h-10 md:w-10"
+          className="h-8 w-8 text-kumo-brand md:h-10 md:w-10"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/src/components/privacy-policy.tsx
+++ b/src/components/privacy-policy.tsx
@@ -1,17 +1,17 @@
 import type React from "react";
-import { Link } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
 export const PrivacyPolicy: React.FC = () => (
   <div className="mx-auto max-w-4xl px-6 py-16">
     <div className="mx-auto max-w-3xl">
-      <h1 className="font-anton text-5xl text-white uppercase tracking-tight md:text-6xl">
+      <h1 className="font-anton text-5xl text-kumo-default uppercase tracking-tight md:text-6xl">
         The Fucking Privacy Policy
       </h1>
-      <p className="mt-4 font-mono text-neutral-400 text-sm">
+      <p className="mt-4 font-mono text-kumo-subtle text-sm">
         Last updated: December 24, 2025
       </p>
 
-      <div className="mt-12 space-y-8 font-sans text-neutral-300">
+      <div className="mt-12 space-y-8 font-sans text-kumo-default">
         <section>
           <p className="mt-4 leading-relaxed">
             Yeah we know, another goddamn wall of lawyer text. But here's the
@@ -22,7 +22,7 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             What We Collect (Spoiler: Not Your Soul)
           </h2>
           <p className="mt-4 leading-relaxed">
@@ -30,7 +30,7 @@ export const PrivacyPolicy: React.FC = () => (
             track you like a stalker ex. It grabs only anonymized, aggregated
             garbage like:
           </p>
-          <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-neutral-400">
+          <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-kumo-subtle">
             <li>Page views and how you stumble around the site</li>
             <li>How long you stare at our beautiful rage</li>
             <li>Referrer (just the domain, not your life story)</li>
@@ -41,7 +41,7 @@ export const PrivacyPolicy: React.FC = () => (
             </li>
           </ul>
           <p className="mt-4 leading-relaxed">
-            <strong className="text-white">
+            <strong className="text-kumo-default">
               NO names. NO emails. NO IP addresses. NO creepy account IDs. NO
               PII. PERIOD.
             </strong>{" "}
@@ -52,7 +52,7 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             Public Shame (Aggregated Only)
           </h2>
           <p className="mt-4 leading-relaxed">
@@ -64,7 +64,7 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             No Cookies. No Bullshit Banners.
           </h2>
           <p className="mt-4 leading-relaxed">
@@ -76,19 +76,19 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             Third-Party Services (The Only Ones We Couldn't Avoid)
           </h2>
-          <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-neutral-400">
+          <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-kumo-subtle">
             <li>
-              <strong className="text-white">Umami Cloud</strong> → analytics
-              (privacy-first, no cookies, anonymized before it even hits their
-              servers)
+              <strong className="text-kumo-default">Umami Cloud</strong> →
+              analytics (privacy-first, no cookies, anonymized before it even
+              hits their servers)
             </li>
             <li>
-              <strong className="text-white">Google Fonts</strong> → pretty
-              letters (they see your IP when fetching fonts because capitalism —
-              check their policy if you care, we're not your mom)
+              <strong className="text-kumo-default">Google Fonts</strong> →
+              pretty letters (they see your IP when fetching fonts because
+              capitalism — check their policy if you care, we're not your mom)
             </li>
           </ul>
           <p className="mt-4 leading-relaxed">
@@ -97,7 +97,7 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             Data Goes Where?
           </h2>
           <p className="mt-4 leading-relaxed">
@@ -107,7 +107,7 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             Your Rights (GDPR & Friends)
           </h2>
           <p className="mt-4 leading-relaxed">
@@ -115,12 +115,12 @@ export const PrivacyPolicy: React.FC = () => (
             "access, rectify, delete or rage-quit over". You win by default.
           </p>
           <p className="mt-4 leading-relaxed">Still wanna fight the power?</p>
-          <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-neutral-400">
+          <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-kumo-subtle">
             <li>Block analytics requests with uBlock/uMatrix/whatever</li>
             <li>
               Cry to Umami at{" "}
               <a
-                className="text-orange-500 transition-colors hover:text-orange-400"
+                className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
                 href="https://umami.is"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -137,7 +137,7 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             Changes to This Policy
           </h2>
           <p className="mt-4 leading-relaxed">
@@ -148,17 +148,17 @@ export const PrivacyPolicy: React.FC = () => (
         </section>
 
         <section>
-          <h2 className="font-anton text-3xl text-white uppercase tracking-tight">
+          <h2 className="font-anton text-3xl text-kumo-default uppercase tracking-tight">
             Contact
           </h2>
           <p className="mt-4 leading-relaxed">
             Got beef? Open an issue here and yell into the void:
           </p>
-          <div className="mt-4 space-y-2 font-mono text-neutral-400">
+          <div className="mt-4 space-y-2 font-mono text-kumo-subtle">
             <p>
               GitHub:{" "}
               <a
-                className="text-orange-500 transition-colors hover:text-orange-400"
+                className="text-kumo-brand transition-colors hover:text-kumo-brand-hover"
                 href="https://github.com/mynameistito/justfuckingusecloudflare"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -169,29 +169,29 @@ export const PrivacyPolicy: React.FC = () => (
           </div>
         </section>
 
-        <section className="mt-12 border-neutral-800 border-t pt-8">
-          <p className="font-anton text-2xl text-white uppercase leading-relaxed tracking-tight">
+        <section className="mt-12 border-kumo-line border-t pt-8">
+          <p className="font-anton text-2xl text-kumo-default uppercase leading-relaxed tracking-tight">
             Stop Fucking Worrying About Privacy Here.
           </p>
-          <p className="mt-4 font-anton text-2xl text-white uppercase leading-relaxed tracking-tight">
+          <p className="mt-4 font-anton text-2xl text-kumo-default uppercase leading-relaxed tracking-tight">
             We're Not The Villains.
           </p>
-          <p className="mt-4 font-anton text-2xl text-white uppercase leading-relaxed tracking-tight">
+          <p className="mt-4 font-anton text-2xl text-kumo-default uppercase leading-relaxed tracking-tight">
             We're The Ones Telling You To Stop Paying several Bills.
           </p>
-          <p className="mt-4 font-anton text-2xl text-orange-500 uppercase leading-relaxed tracking-tight">
-            Just FuckingUse Cloudflare.
+          <p className="mt-4 font-anton text-2xl text-kumo-brand uppercase leading-relaxed tracking-tight">
+            Just Fucking Use Cloudflare.
           </p>
         </section>
       </div>
 
-      <div className="mt-12 border-neutral-800 border-t pt-8">
-        <Link
-          className="inline-flex items-center gap-2 rounded-full border border-neutral-700 bg-transparent px-4 py-2 font-mono text-neutral-400 text-sm transition-all hover:border-orange-500 hover:text-orange-500 focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-2"
+      <div className="mt-12 border-kumo-line border-t pt-8">
+        <RouterLink
+          className="inline-flex items-center gap-2 rounded-full border border-kumo-line bg-transparent px-4 py-2 font-mono text-kumo-subtle text-sm transition-all hover:border-kumo-brand hover:text-kumo-brand focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-2"
           to="/"
         >
           ← Back to Home
-        </Link>
+        </RouterLink>
       </div>
     </div>
   </div>

--- a/src/components/rant.tsx
+++ b/src/components/rant.tsx
@@ -5,79 +5,81 @@ export const Rant: React.FC = () => {
   const { to } = usePersonalization();
 
   return (
-    <section className="border-neutral-800 border-b bg-neutral-950 px-6 py-24 md:py-32">
+    <section className="border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
       <div className="mx-auto max-w-4xl">
-        <h2 className="mb-8 font-anton text-4xl text-white uppercase tracking-tight md:text-5xl lg:text-6xl">
+        <h2 className="mb-8 font-anton text-4xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
           {to ? (
             <>
-              <span className="text-orange-500">{to.toUpperCase()}</span>,
-              YOU'RE <span className="text-orange-500">FUCKING</span> KILLING ME
+              <span className="text-kumo-brand">{to.toUpperCase()}</span>,
+              YOU'RE <span className="text-kumo-brand">FUCKING</span> KILLING ME
               HERE
             </>
           ) : (
             <>
-              YOU'RE <span className="text-orange-500">FUCKING</span> KILLING ME
+              YOU'RE <span className="text-kumo-brand">FUCKING</span> KILLING ME
               HERE
             </>
           )}
         </h2>
-        <div className="space-y-6 font-mono text-base text-neutral-300 leading-relaxed md:text-lg">
+        <div className="space-y-6 font-mono text-base text-kumo-default leading-relaxed md:text-lg">
           <p>
             {to ? `${to}, y` : "Y"}ou've got Vercel for frontend, Railway for
             backend, AWS S3 for storage, PlanetScale for DB, Redis Labs for
             cache, Cloudinary for images, and you're paying{" "}
-            <strong className="text-white">
+            <strong className="text-kumo-default">
               FIVE DIFFERENT CORPORATE OVERLORDS
             </strong>{" "}
             to keep your half-baked blog alive.
           </p>
           <p>
             Meanwhile Cloudflare is literally{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               BEGGING
             </span>{" "}
             you to use their{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               Workers
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               Pages
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               R2
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               D1
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               KV
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               Durable Objects
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               Queues
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               Workflows
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               AI
             </span>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
               Vectorize
             </span>{" "}
             — ALL ON ONE PLATFORM, ONE BILL, AND{" "}
-            <strong className="text-white">ACTUALLY GENEROUS FREE TIERS</strong>
+            <strong className="text-kumo-default">
+              ACTUALLY GENEROUS FREE TIERS
+            </strong>
             .
           </p>
         </div>

--- a/src/components/rant.tsx
+++ b/src/components/rant.tsx
@@ -1,3 +1,5 @@
+import { Banner, Surface, Text } from "@cloudflare/kumo";
+import { WarningIcon } from "@phosphor-icons/react";
 import type React from "react";
 import { usePersonalization } from "../hooks/use-personalization";
 
@@ -21,68 +23,34 @@ export const Rant: React.FC = () => {
             </>
           )}
         </h2>
-        <div className="space-y-6 font-mono text-base text-kumo-default leading-relaxed md:text-lg">
-          <p>
-            {to ? `${to}, y` : "Y"}ou've got Vercel for frontend, Railway for
-            backend, AWS S3 for storage, PlanetScale for DB, Redis Labs for
-            cache, Cloudinary for images, and you're paying{" "}
-            <strong className="text-kumo-default">
-              FIVE DIFFERENT CORPORATE OVERLORDS
-            </strong>{" "}
-            to keep your half-baked blog alive.
-          </p>
-          <p>
-            Meanwhile Cloudflare is literally{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              BEGGING
-            </span>{" "}
-            you to use their{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              Workers
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              Pages
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              R2
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              D1
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              KV
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              Durable Objects
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              Queues
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              Workflows
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              AI
-            </span>
-            ,{" "}
-            <span className="bg-gradient-to-r from-kumo-brand to-orange-400 bg-clip-text font-bold text-transparent">
-              Vectorize
-            </span>{" "}
-            — ALL ON ONE PLATFORM, ONE BILL, AND{" "}
-            <strong className="text-kumo-default">
-              ACTUALLY GENEROUS FREE TIERS
-            </strong>
-            .
-          </p>
+
+        <div className="mb-8">
+          <Banner
+            description={`${to ? `${to}, you've` : "You've"} got Vercel for frontend, Railway for backend, AWS S3 for storage, PlanetScale for DB, Redis Labs for cache, Cloudinary for images — and you're paying FIVE DIFFERENT CORPORATE OVERLORDS to keep your half-baked blog alive.`}
+            icon={<WarningIcon weight="fill" />}
+            title="You're burning money"
+            variant="alert"
+          />
         </div>
+
+        <Surface className="rounded-xl p-6 md:p-8">
+          <Text size="base">
+            Meanwhile Cloudflare is literally{" "}
+            <span className="font-bold text-kumo-brand">BEGGING</span> you to
+            use their <span className="font-bold text-kumo-brand">Workers</span>
+            , <span className="font-bold text-kumo-brand">Pages</span>,{" "}
+            <span className="font-bold text-kumo-brand">R2</span>,{" "}
+            <span className="font-bold text-kumo-brand">D1</span>,{" "}
+            <span className="font-bold text-kumo-brand">KV</span>,{" "}
+            <span className="font-bold text-kumo-brand">Durable Objects</span>,{" "}
+            <span className="font-bold text-kumo-brand">Queues</span>,{" "}
+            <span className="font-bold text-kumo-brand">Workflows</span>,{" "}
+            <span className="font-bold text-kumo-brand">AI</span>,{" "}
+            <span className="font-bold text-kumo-brand">Vectorize</span> — ALL
+            ON ONE PLATFORM, ONE BILL, AND{" "}
+            <strong>ACTUALLY GENEROUS FREE TIERS</strong>.
+          </Text>
+        </Surface>
       </div>
     </section>
   );

--- a/src/components/share-link.tsx
+++ b/src/components/share-link.tsx
@@ -1,3 +1,4 @@
+import { Surface } from "@cloudflare/kumo";
 import type React from "react";
 import { useEffect, useState } from "react";
 import {
@@ -45,12 +46,12 @@ export const ShareLink: React.FC = () => {
   const previewYourName = normalizeName(yourName) ?? "";
 
   return (
-    <section className="border-neutral-800 border-b bg-neutral-950 px-6 py-24 md:py-32">
+    <section className="border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
       <div className="mx-auto max-w-4xl">
-        <h2 className="mb-8 font-anton text-4xl text-white uppercase tracking-tight md:text-5xl lg:text-6xl">
-          KNOW SOMEONE WHO NEEDS <span className="text-orange-500">HELP</span>?
+        <h2 className="mb-8 font-anton text-4xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
+          KNOW SOMEONE WHO NEEDS <span className="text-kumo-brand">HELP</span>?
         </h2>
-        <p className="mb-8 font-mono text-base text-neutral-400 md:text-lg">
+        <p className="mb-8 font-mono text-kumo-subtle text-lg md:text-lg">
           Share this link with them. They'll see a personalized version just for
           them.
         </p>
@@ -58,13 +59,13 @@ export const ShareLink: React.FC = () => {
         <div className="space-y-6">
           <div>
             <label
-              className="mb-2 block font-bold font-mono text-neutral-300 text-sm uppercase tracking-tight"
+              className="mb-2 block font-bold font-mono text-kumo-default text-sm uppercase tracking-tight"
               htmlFor="your-name"
             >
               Your Name
             </label>
             <input
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3 font-mono text-white placeholder:text-neutral-600 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50"
+              className="w-full rounded-lg border border-kumo-line bg-kumo-elevated px-4 py-3 font-mono text-kumo-default placeholder:text-kumo-inactive focus:border-kumo-brand focus:outline-none focus:ring-2 focus:ring-kumo-brand/50"
               id="your-name"
               onChange={(e) => {
                 setYourName(e.target.value);
@@ -77,13 +78,13 @@ export const ShareLink: React.FC = () => {
 
           <div>
             <label
-              className="mb-2 block font-bold font-mono text-neutral-300 text-sm uppercase tracking-tight"
+              className="mb-2 block font-bold font-mono text-kumo-default text-sm uppercase tracking-tight"
               htmlFor="their-name"
             >
               Their Name
             </label>
             <input
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3 font-mono text-white placeholder:text-neutral-600 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50"
+              className="w-full rounded-lg border border-kumo-line bg-kumo-elevated px-4 py-3 font-mono text-kumo-default placeholder:text-kumo-inactive focus:border-kumo-brand focus:outline-none focus:ring-2 focus:ring-kumo-brand/50"
               id="their-name"
               onChange={(e) => {
                 setTheirName(e.target.value);
@@ -95,20 +96,20 @@ export const ShareLink: React.FC = () => {
           </div>
 
           {previewTheirName && previewYourName && (
-            <div className="rounded-lg border border-neutral-700 bg-neutral-900 p-4">
-              <p className="font-mono text-neutral-400 text-sm">
+            <Surface className="rounded-lg p-4">
+              <p className="font-mono text-kumo-subtle text-sm">
                 They'll see:{" "}
-                <span className="text-orange-500">
+                <span className="text-kumo-brand">
                   "Hey {previewTheirName}, if {previewYourName} sent you this
                   link, you need to..."
                 </span>
               </p>
-            </div>
+            </Surface>
           )}
 
           <button
             aria-label="Copy share link"
-            className="w-full rounded-full border-2 border-orange-500 bg-orange-500 px-10 py-5 font-bold font-mono text-black uppercase tracking-tight transition-all hover:bg-orange-400 hover:shadow-[0_0_40px_rgba(246,130,31,0.4)] focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-4 active:bg-orange-600 disabled:cursor-not-allowed disabled:border-neutral-700 disabled:bg-neutral-800 disabled:text-neutral-500 disabled:hover:bg-neutral-800 disabled:hover:shadow-none sm:w-auto"
+            className="brand-glow w-full rounded-full border-2 border-kumo-brand bg-kumo-brand px-10 py-5 font-bold font-mono text-kumo-canvas uppercase tracking-tight transition-all hover:bg-kumo-brand-hover focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-4 active:opacity-80 disabled:cursor-not-allowed disabled:border-kumo-line disabled:bg-kumo-fill disabled:text-kumo-inactive disabled:hover:bg-kumo-fill disabled:hover:shadow-none sm:w-auto"
             disabled={isDisabled}
             onClick={handleCopyLink}
             type="button"

--- a/src/components/share-link.tsx
+++ b/src/components/share-link.tsx
@@ -1,4 +1,5 @@
-import { Surface } from "@cloudflare/kumo";
+import { Button, Input, Surface, Text } from "@cloudflare/kumo";
+import { CopyIcon } from "@phosphor-icons/react";
 import type React from "react";
 import { useEffect, useState } from "react";
 import {
@@ -41,81 +42,58 @@ export const ShareLink: React.FC = () => {
   };
 
   const isDisabled = !(theirName.trim() && yourName.trim());
-
   const previewTheirName = normalizeName(theirName) ?? "";
   const previewYourName = normalizeName(yourName) ?? "";
 
   return (
     <section className="border-kumo-line border-b bg-kumo-canvas px-6 py-24 md:py-32">
-      <div className="mx-auto max-w-4xl">
-        <h2 className="mb-8 font-anton text-4xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
+      <div className="mx-auto max-w-2xl">
+        <h2 className="mb-4 font-anton text-4xl text-kumo-default uppercase tracking-tight md:text-5xl lg:text-6xl">
           KNOW SOMEONE WHO NEEDS <span className="text-kumo-brand">HELP</span>?
         </h2>
-        <p className="mb-8 font-mono text-kumo-subtle text-lg md:text-lg">
-          Share this link with them. They'll see a personalized version just for
-          them.
+        <p className="mb-10 font-mono text-kumo-subtle text-lg">
+          Generate a personalised link. They'll see a version addressed directly
+          to them.
         </p>
 
-        <div className="space-y-6">
-          <div>
-            <label
-              className="mb-2 block font-bold font-mono text-kumo-default text-sm uppercase tracking-tight"
-              htmlFor="your-name"
-            >
-              Your Name
-            </label>
-            <input
-              className="w-full rounded-lg border border-kumo-line bg-kumo-elevated px-4 py-3 font-mono text-kumo-default placeholder:text-kumo-inactive focus:border-kumo-brand focus:outline-none focus:ring-2 focus:ring-kumo-brand/50"
-              id="your-name"
-              onChange={(e) => {
-                setYourName(e.target.value);
-              }}
-              placeholder="Enter your name"
-              type="text"
-              value={yourName}
-            />
-          </div>
+        <div className="flex flex-col gap-6">
+          <Input
+            label="Your Name"
+            onChange={(e) => setYourName(e.target.value)}
+            placeholder="Enter your name"
+            value={yourName}
+          />
 
-          <div>
-            <label
-              className="mb-2 block font-bold font-mono text-kumo-default text-sm uppercase tracking-tight"
-              htmlFor="their-name"
-            >
-              Their Name
-            </label>
-            <input
-              className="w-full rounded-lg border border-kumo-line bg-kumo-elevated px-4 py-3 font-mono text-kumo-default placeholder:text-kumo-inactive focus:border-kumo-brand focus:outline-none focus:ring-2 focus:ring-kumo-brand/50"
-              id="their-name"
-              onChange={(e) => {
-                setTheirName(e.target.value);
-              }}
-              placeholder="Enter their name"
-              type="text"
-              value={theirName}
-            />
-          </div>
+          <Input
+            label="Their Name"
+            onChange={(e) => setTheirName(e.target.value)}
+            placeholder="Enter their name"
+            value={theirName}
+          />
 
           {previewTheirName && previewYourName && (
             <Surface className="rounded-lg p-4">
-              <p className="font-mono text-kumo-subtle text-sm">
+              <Text color="subtle" size="sm">
                 They'll see:{" "}
                 <span className="text-kumo-brand">
                   "Hey {previewTheirName}, if {previewYourName} sent you this
                   link, you need to..."
                 </span>
-              </p>
+              </Text>
             </Surface>
           )}
 
-          <button
-            aria-label="Copy share link"
-            className="brand-glow w-full rounded-full border-2 border-kumo-brand bg-kumo-brand px-10 py-5 font-bold font-mono text-kumo-canvas uppercase tracking-tight transition-all hover:bg-kumo-brand-hover focus-visible:outline-2 focus-visible:outline-kumo-brand focus-visible:outline-offset-4 active:opacity-80 disabled:cursor-not-allowed disabled:border-kumo-line disabled:bg-kumo-fill disabled:text-kumo-inactive disabled:hover:bg-kumo-fill disabled:hover:shadow-none sm:w-auto"
-            disabled={isDisabled}
-            onClick={handleCopyLink}
-            type="button"
-          >
-            {copied ? "LINK COPIED!" : "COPY SHARE LINK"}
-          </button>
+          <div>
+            <Button
+              disabled={isDisabled}
+              icon={CopyIcon}
+              onClick={handleCopyLink}
+              size="lg"
+              variant="primary"
+            >
+              {copied ? "LINK COPIED!" : "COPY SHARE LINK"}
+            </Button>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/thank-you.tsx
+++ b/src/components/thank-you.tsx
@@ -1,3 +1,4 @@
+import { Banner } from "@cloudflare/kumo";
 import type React from "react";
 
 interface ThankYouProps {
@@ -6,13 +7,14 @@ interface ThankYouProps {
 
 export const ThankYou: React.FC<ThankYouProps> = ({ from }) => {
   return (
-    <section className="border-neutral-800 border-b bg-neutral-950 px-6 py-12">
+    <section className="border-kumo-line border-b bg-kumo-canvas px-6 py-12">
       <div className="mx-auto max-w-4xl text-center">
-        <p className="font-mono text-lg text-neutral-400 md:text-xl">
-          Don't forget to fucking thank{" "}
-          <span className="font-bold text-orange-500">{from}</span> for sending
-          you this link. They're looking out for you.
-        </p>
+        <Banner
+          title={`Don't forget to fucking thank ${from}`}
+          variant="default"
+        >
+          They're looking out for you.
+        </Banner>
       </div>
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,126 @@
 @import "tailwindcss";
+@import "@cloudflare/kumo/styles";
+
+@theme {
+  --color-jfuc-brand: #f6821f;
+  --color-jfuc-brand-hover: #e67320;
+  --color-jfuc-brand-glow: rgba(246, 130, 31, 0.4);
+  --color-jfuc-brand-glow-subtle: rgba(246, 130, 31, 0.1);
+  --font-anton: "Anton", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+  --font-sans: "Space Grotesk", sans-serif;
+}
+
+@layer base {
+  [data-mode="dark"] {
+    --color-kumo-brand: var(--color-jfuc-brand);
+    --color-kumo-brand-hover: var(--color-jfuc-brand-hover);
+  }
+
+  [data-mode="light"] {
+    --color-kumo-brand: var(--color-jfuc-brand);
+    --color-kumo-brand-hover: var(--color-jfuc-brand-hover);
+  }
+
+  body {
+    font-family: var(--font-sans);
+    color: var(--color-kumo-default);
+    background-color: var(--color-kumo-canvas);
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  ::selection {
+    color: var(--color-kumo-canvas);
+    background: var(--color-jfuc-brand);
+  }
+
+  *:focus-visible {
+    outline: 2px solid var(--color-jfuc-brand);
+    outline-offset: 2px;
+  }
+}
+
+@layer components {
+  .font-anton {
+    font-family: var(--font-anton);
+  }
+
+  .font-mono {
+    font-family: var(--font-mono);
+  }
+
+  .noise::before {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 50;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    content: "";
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+    opacity: 0.03;
+  }
+
+  @keyframes float {
+    0% {
+      transform: translateY(0px);
+    }
+    50% {
+      transform: translateY(-20px);
+    }
+    100% {
+      transform: translateY(0px);
+    }
+  }
+
+  .animate-float {
+    animation: float 6s ease-in-out infinite;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    white-space: nowrap;
+    border-width: 0;
+    clip: rect(0, 0, 0, 0);
+  }
+
+  .focus\:not-sr-only:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: inherit;
+    margin: inherit;
+    overflow: visible;
+    white-space: normal;
+    clip: auto;
+  }
+
+  * {
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+    transition-property:
+      color, background-color, border-color, text-decoration-color, fill,
+      stroke, opacity, box-shadow, transform;
+  }
+}
+
+@utility brand-glow {
+  box-shadow: 0 0 40px var(--color-jfuc-brand-glow);
+}
+
+@utility brand-glow-subtle {
+  box-shadow: 0 0 30px var(--color-jfuc-brand-glow-subtle);
+}
+
+@utility brand-glow-focus {
+  box-shadow: 0 0 20px rgba(246, 130, 31, 0.2);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-mode="dark">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -62,97 +62,6 @@
       href="https://fonts.googleapis.com/css2?family=Anton&family=JetBrains+Mono:wght@400;700&family=Space+Grotesk:wght@400;500;700&display=swap"
       rel="stylesheet"
     >
-    <style>
-    body {
-      font-family: "Space Grotesk", sans-serif;
-      color: #fafafa;
-      background-color: #0a0a0a;
-    }
-    .font-anton {
-      font-family: "Anton", sans-serif;
-    }
-    .font-mono {
-      font-family: "JetBrains Mono", monospace;
-    }
-
-    /* Subtle noise overlay */
-    .noise::before {
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: 50;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
-      content: "";
-      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-      opacity: 0.03;
-    }
-
-    ::selection {
-      color: #0a0a0a;
-      background: #f6821f;
-    }
-
-    @keyframes float {
-      0% {
-        transform: translateY(0px);
-      }
-      50% {
-        transform: translateY(-20px);
-      }
-      100% {
-        transform: translateY(0px);
-      }
-    }
-    .animate-float {
-      animation: float 6s ease-in-out infinite;
-    }
-
-    /* Smooth scroll */
-    html {
-      scroll-behavior: smooth;
-    }
-
-    /* Better focus states for accessibility */
-    *:focus-visible {
-      outline: 2px solid #f6821f;
-      outline-offset: 2px;
-    }
-
-    /* Smooth transitions */
-    * {
-      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-      transition-duration: 150ms;
-      transition-property:
-        color, background-color, border-color, text-decoration-color, fill,
-        stroke, opacity, box-shadow, transform;
-    }
-
-    /* Screen reader only */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      white-space: nowrap;
-      border-width: 0;
-      clip: rect(0, 0, 0, 0);
-    }
-
-    .focus\:not-sr-only:focus {
-      position: static;
-      width: auto;
-      height: auto;
-      padding: inherit;
-      margin: inherit;
-      overflow: visible;
-      white-space: normal;
-      clip: auto;
-    }
-    </style>
   </head>
   <body class="noise">
     <div id="root"></div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "strictNullChecks": true
-  }
+  },
+  "exclude": ["opensrc"]
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the app to `@cloudflare/kumo` for UI and theming, refresh key pages, and replace `lucide-react` icons with `@phosphor-icons/react`. Moves styling into a consistent dark theme with improved accessibility.

- **Refactors**
  - Migrate to Kumo tokens and components (`Badge`, `Button`, `Tabs`, `Text`, `Surface`, `Banner`, `Link`, `Table`, `LayerCard`).
  - Rework hero, CTA, comparison (table), features (tabs), share link, rant, footer, thank you, and privacy policy to use Kumo and new color system.
  - Improve accessibility: better skip-link styling, smoother scrolling, higher-contrast text, and semantic text components.
  - Set global dark mode via `data-mode="dark"`; move theme and utilities into `src/index.css`; remove inlined CSS from `index.html`.
  - Add `opensrc/` vendor source mirror and docs; ignore in Git and exclude from TypeScript.

- **Dependencies**
  - Add `@cloudflare/kumo` and `@phosphor-icons/react`; remove `lucide-react`.
  - Add `@types/react`, `@types/react-dom`, and `src/vite-env.d.ts`.
  - Update `bun.lock`; no runtime API changes expected.

<sup>Written for commit ec70974d5ef79df94b5fdfcdb23195dfae660625. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the entire UI to the `@cloudflare/kumo` design system, replacing custom Tailwind utility classes with Kumo components (`Badge`, `Banner`, `Button`, `Input`, `LayerCard`, `Link`, `Surface`, `Table`, `Tabs`, `Text`). CSS is updated to import kumo styles and wire up the brand colour tokens, and `AGENTS.md` is updated to reflect the new dependency. The changes are largely cosmetic/structural with no new logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a clean kumo design-system migration with no logic changes and only P2 style/accessibility findings.

All findings are P2 (prefers-reduced-motion guard, missing main landmark, minor type cast). No data-integrity, security, or runtime-correctness issues were identified. The three suggestions are improvements, not blockers.

src/index.css (global transition), src/components/privacy-policy.tsx (missing main landmark), src/components/features.tsx (type cast)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/features.tsx | New tab-based feature section using kumo Tabs/Badge/Text; contains a minor unsafe type cast `v as Tab` on onValueChange. |
| src/components/privacy-policy.tsx | Privacy policy page uses raw `<a>` tags inconsistently with the rest of the app (which uses kumo Link) and lacks a `<main>` landmark element. |
| src/index.css | Adds kumo styles import and theme tokens; global `*` transition block is missing a prefers-reduced-motion guard. |
| src/components/comparison.tsx | Migrated to kumo LayerCard/Table/Badge; icons stored as module-level JSX constants — clean implementation. |
| src/components/share-link.tsx | Migrated to kumo Input/Button/Surface/Text; URL encoding and clipboard handling correct. |
| src/components/footer.tsx | Migrated to kumo Link/Text components; all external links include rel="noopener noreferrer". |
| src/components/hero.tsx | Migrated to kumo Button; personalization logic unchanged and correct. |
| src/components/rant.tsx | Migrated to kumo Banner/Surface/Text; no issues. |
| src/components/cta.tsx | Migrated to kumo Button; window.open uses noopener,noreferrer correctly. |
| src/components/thank-you.tsx | Migrated to kumo Banner; simple and correct. |
| src/app.tsx | Router composition and scroll-to-top logic unchanged; the `if (pathname)` guard is always true but harmless. |
| package.json | Added @cloudflare/kumo dependency; other deps look consistent. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["BrowserRouter"] --> B["ScrollToTop"]
    A --> C["Routes"]
    C --> D["/ → HomePage"]
    C --> E["/privacy-policy → PrivacyPolicy"]

    D --> F["Hero\n(kumo Button)"]
    D --> G["Rant\n(kumo Banner, Surface, Text)"]
    D --> H["Comparison\n(kumo LayerCard, Table, Badge)"]
    D --> I["Features\n(kumo Tabs, Badge, Text)"]
    D --> J["CTA\n(kumo Button)"]
    D --> K["ShareLink\n(kumo Input, Button, Surface)"]
    D --> L{"from param?"}
    L -- yes --> M["ThankYou\n(kumo Banner)"]
    D --> N["Footer\n(kumo Link, Text)"]

    subgraph Kumo Design System
        KDS["@cloudflare/kumo\nBadge · Banner · Button · Input\nLayerCard · Link · Surface\nTable · Tabs · Text"]
    end

    F & G & H & I & J & K & M & N --> KDS
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/features.tsx
Line: 98

Comment:
**Unsafe `as Tab` cast on `onValueChange`**

The `v as Tab` cast silently accepts any string the `Tabs` component passes. If the kumo `Tabs` component ever emits an unexpected value, `features[activeTab]` would be `undefined` and the subsequent `.map()` call would throw at runtime. Consider narrowing the value first:

```suggestion
          onValueChange={(v) => { if (Object.keys(features).includes(v)) setActiveTab(v as Tab); }}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/privacy-policy.tsx
Line: 4-5

Comment:
**Missing `<main>` landmark and inconsistent link usage**

The privacy policy page root is a bare `<div>`, while every other route wraps content in `<main id="main-content">`. Screen readers won't have a main landmark to jump to. The inline `<a>` tags at lines 122–130 and 160–169 also bypass the kumo `Link` component used everywhere else in the app — consider swapping them for `<Link variant="inline">` for consistent focus/hover styles.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/index.css
Line: 107-113

Comment:
**Global `*` transitions miss `prefers-reduced-motion`**

Applying `transition-duration: 150ms` to every element unconditionally will animate motion for users who have requested reduced motion in their OS settings. Wrapping this in a media query is the standard fix:

```suggestion
  @media (prefers-reduced-motion: no-preference) {
    * {
      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
      transition-duration: 150ms;
      transition-property:
        color, background-color, border-color, text-decoration-color, fill,
        stroke, opacity, box-shadow, transform;
    }
  }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["update"](https://github.com/mynameistito/justfuckingusecloudflare/commit/ec70974d5ef79df94b5fdfcdb23195dfae660625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28007106)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->