### PR TITLE
Dep Updates 2026-04-17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "lefthook": "^2.1.6",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.2",
-        "ultracite": "7.5.9",
+        "ultracite": "7.6.0",
         "vite": "^8.0.8",
         "wrangler": "^4.83.0",
       },
@@ -436,7 +436,7 @@
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "ultracite": ["ultracite@7.5.9", "", { "dependencies": { "@clack/prompts": "^1.2.0", "commander": "^14.0.3", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5", "yaml": "^2.8.3", "zod": "^4.3.2" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-6UBZNXqUm9tosAQ/nBQaWeCHWBcOVZmDl9Jfg33o9jSrUSTobpphI23Wh72tc8iYPTR3tXGHWhO+GvC7w/QyQQ=="],
+    "ultracite": ["ultracite@7.6.0", "", { "dependencies": { "@clack/prompts": "^1.2.0", "commander": "^14.0.3", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5", "yaml": "^2.8.3", "zod": "^4.3.6" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-i8Pmi7Tgtku00/4od12nLiLjgO92+DmuRWTIFApe4f6n8osYT98QLcEdsf7xpJiZflyc8gsONWbFw0RvhO9QzQ=="],
 
     "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lefthook": "^2.1.6",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "ultracite": "7.5.9",
+    "ultracite": "7.6.0",
     "vite": "^8.0.8",
     "wrangler": "^4.83.0"
   },

--- a/src/components/thank-you.tsx
+++ b/src/components/thank-you.tsx
@@ -4,16 +4,14 @@ interface ThankYouProps {
   from: string;
 }
 
-export const ThankYou: React.FC<ThankYouProps> = ({ from }) => {
-  return (
-    <section className="border-neutral-800 border-b bg-neutral-950 px-6 py-12">
-      <div className="mx-auto max-w-4xl text-center">
-        <p className="font-mono text-lg text-neutral-400 md:text-xl">
-          Don't forget to fucking thank{" "}
-          <span className="font-bold text-orange-500">{from}</span> for sending
-          you this link. They're looking out for you.
-        </p>
-      </div>
-    </section>
-  );
-};
+export const ThankYou: React.FC<ThankYouProps> = ({ from }) => (
+  <section className="border-neutral-800 border-b bg-neutral-950 px-6 py-12">
+    <div className="mx-auto max-w-4xl text-center">
+      <p className="font-mono text-lg text-neutral-400 md:text-xl">
+        Don't forget to fucking thank{" "}
+        <span className="font-bold text-orange-500">{from}</span> for sending
+        you this link. They're looking out for you.
+      </p>
+    </div>
+  </section>
+);


### PR DESCRIPTION
Dep Updates 2026-04-17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `ultracite` from 7.5.9 to 7.6.0 and update `bun.lock` (transitive `zod` to ^4.3.6). Also simplify the `ThankYou` component to a concise functional return with no behavior change.

<sup>Written for commit 2bf368ce9e8c1ee440ba6c4c6b7d6da90900370b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `ultracite` dependency from 7.5.9 to 7.6.0
> Updates `ultracite` in [package.json](https://github.com/mynameistito/justfuckingusecloudflare/pull/57/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to 7.6.0, which also tightens its transitive `zod` constraint from `^4.3.2` to `^4.3.6`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 910f653.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->