### PR TITLE
rm umami

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,9 +1,4 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "extends": [
-    "ultracite/core",
-    "ultracite/react",
-    "ultracite/biome/core",
-    "ultracite/biome/react"
-  ]
+  "extends": ["ultracite/biome/core", "ultracite/biome/react"]
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "jfuc---just-fucking-use-cloudflare",
+  "name": "just-fucking-use-cloudflare",
   "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "portless justfuckingusecloudflare vite",
     "build": "vite build",
     "preview": "vite preview",
     "deploy": "node scripts/deploy.js",

--- a/src/components/comparison.tsx
+++ b/src/components/comparison.tsx
@@ -16,6 +16,7 @@ const cards = [
     vs: "CloudFront, Akamai, Fastly",
     desc: "Global anycast CDN with built-in DDoS protection and smart caching. No extra boxes, no multi-vendor dance.",
     free: "Global CDN included on every plan",
+    url: "https://www.cloudflare.com/application-services/products/cdn/",
   },
   {
     icon: <Database className="h-6 w-6" />,
@@ -23,6 +24,7 @@ const cards = [
     vs: "PlanetScale, Supabase, Neon",
     desc: "Serverless SQLite with read replication. Query at the edge. No connection pooling headaches.",
     free: "5M reads/day FREE",
+    url: "https://www.cloudflare.com/developer-platform/products/d1/",
   },
   {
     icon: <Link className="h-6 w-6" />,
@@ -30,6 +32,7 @@ const cards = [
     vs: "GoDaddy scams",
     desc: "Domains at actual wholesale cost. No renewal traps. Free privacy.",
     free: "No bullshit pricing",
+    url: "https://domains.cloudflare.com",
   },
   {
     icon: <Package className="h-6 w-6" />,
@@ -37,6 +40,7 @@ const cards = [
     vs: "S3, GCS, Azure Blob",
     desc: "S3-compatible object storage with zero egress fees. Stop letting AWS rob you blind.",
     free: "10GB storage FREE • $0 egress FOREVER",
+    url: "https://www.cloudflare.com/developer-platform/products/r2/",
   },
   {
     icon: <Zap className="h-6 w-6" />,
@@ -44,6 +48,7 @@ const cards = [
     vs: "SQS, SNS, RabbitMQ",
     desc: "Guaranteed message delivery with zero egress fees. Offload work, batch data, and connect Workers seamlessly.",
     free: "Zero egress fees • At-least-once delivery",
+    url: "https://www.cloudflare.com/developer-platform/products/cloudflare-queues/",
   },
   {
     icon: <Globe className="h-6 w-6" />,
@@ -51,6 +56,7 @@ const cards = [
     vs: "Vercel, Netlify",
     desc: "Unlimited bandwidth. Real previews. Git integration. Just works.",
     free: "Unlimited sites FREE",
+    url: "https://www.cloudflare.com/developer-platform/products/pages/",
   },
   {
     icon: <Brain className="h-6 w-6" />,
@@ -58,6 +64,7 @@ const cards = [
     vs: "OpenAI, Replicate",
     desc: "Run LLMs at the edge. No infra. No GPUs to manage.",
     free: "10k neurons/day FREE",
+    url: "https://www.cloudflare.com/developer-platform/products/workers-ai/",
   },
   {
     icon: <Zap className="h-6 w-6" />,
@@ -65,6 +72,7 @@ const cards = [
     vs: "Lambda, Vercel Functions",
     desc: "V8 isolates with 0ms cold starts. No containers, no VMs, just instant execution at 300+ edge locations.",
     free: "100k requests/day FREE",
+    url: "https://www.cloudflare.com/developer-platform/products/workers/",
   },
   {
     icon: <GitBranch className="h-6 w-6" />,
@@ -72,6 +80,7 @@ const cards = [
     vs: "Step Functions, Temporal",
     desc: "Durable execution for reliable long-running tasks. Auto-resumes on failure. No infrastructure to manage.",
     free: "Built into Workers platform",
+    url: "https://www.cloudflare.com/developer-platform/products/workflows/",
   },
 ];
 
@@ -90,38 +99,42 @@ export const Comparison: React.FC = () => (
           const isCdnCard = card.title === "CDN";
 
           return (
-            <article
-              className="group rounded-2xl border border-neutral-800 bg-neutral-900 p-6 transition-all duration-300 hover:border-orange-500/50 hover:shadow-[0_0_30px_rgba(246,130,31,0.1)] md:p-8"
+            <a
+              href={card.url}
               key={card.title}
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <div className="mb-6 flex items-start gap-4">
-                <div className="rounded-xl bg-orange-500/10 p-3 text-orange-500 transition-colors group-hover:bg-orange-500 group-hover:text-black">
-                  {card.icon}
+              <article className="group rounded-2xl border border-neutral-800 bg-neutral-900 p-6 transition-all duration-300 hover:border-orange-500/50 hover:shadow-[0_0_30px_rgba(246,130,31,0.1)] md:p-8">
+                <div className="mb-6 flex items-start gap-4">
+                  <div className="rounded-xl bg-orange-500/10 p-3 text-orange-500 transition-colors group-hover:bg-orange-500 group-hover:text-black">
+                    {card.icon}
+                  </div>
+                  <div>
+                    <h3 className="font-anton text-2xl uppercase tracking-wide transition-colors group-hover:text-orange-400">
+                      {card.title}
+                    </h3>
+                    <p className="mt-1 font-mono text-neutral-500 text-xs uppercase">
+                      vs. {card.vs}
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <h3 className="font-anton text-2xl uppercase tracking-wide transition-colors group-hover:text-orange-400">
-                    {card.title}
-                  </h3>
-                  <p className="mt-1 font-mono text-neutral-500 text-xs uppercase">
-                    vs. {card.vs}
-                  </p>
+                <p
+                  className={
+                    isCdnCard
+                      ? "mb-6 min-h-[60px] text-neutral-400 text-xs leading-snug md:h-16 md:text-sm"
+                      : "mb-6 min-h-[80px] text-neutral-400 text-sm leading-relaxed md:h-20 md:text-base"
+                  }
+                >
+                  {card.desc}
+                </p>
+                <div className="border-neutral-800 border-t pt-6">
+                  <span className="rounded-full border border-orange-500/20 bg-orange-500/5 px-3 py-1 font-bold font-mono text-orange-500 text-xs uppercase tracking-tighter">
+                    {card.free}
+                  </span>
                 </div>
-              </div>
-              <p
-                className={
-                  isCdnCard
-                    ? "mb-6 min-h-[60px] text-neutral-400 text-xs leading-snug md:h-16 md:text-sm"
-                    : "mb-6 min-h-[80px] text-neutral-400 text-sm leading-relaxed md:h-20 md:text-base"
-                }
-              >
-                {card.desc}
-              </p>
-              <div className="border-neutral-800 border-t pt-6">
-                <span className="rounded-full border border-orange-500/20 bg-orange-500/5 px-3 py-1 font-bold font-mono text-orange-500 text-xs uppercase tracking-tighter">
-                  {card.free}
-                </span>
-              </div>
-            </article>
+              </article>
+            </a>
           );
         })}
       </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -50,6 +50,15 @@ export const Footer: React.FC = () => (
           >
             Community
           </a>
+          <a
+            aria-label="Cloudflare Domains"
+            className="rounded-full border border-neutral-700 bg-transparent px-4 py-2 font-mono text-neutral-400 text-sm transition-all hover:border-orange-500 hover:text-orange-500 focus-visible:outline-2 focus-visible:outline-orange-500 focus-visible:outline-offset-2"
+            href="https://www.cloudflare.com/products/registrar/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Domains
+          </a>
         </div>
       </div>
       <div className="mt-8 border-neutral-800 border-t pt-8 text-center">
@@ -112,44 +121,7 @@ export const Footer: React.FC = () => (
             target="_blank"
           >
             mynameistito
-          </a>{" "}
-          (
-          <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
-            href="https://buymeacoffee.com/mynameistito"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Buy Me a Coffee
           </a>
-          ,{" "}
-          <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
-            href="https://discord.com/users/611746802122620937"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Discord
-          </a>
-          ,{" "}
-          <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
-            href="https://github.com/mynameistito/justfuckingusecloudflare"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            GitHub
-          </a>
-          ,{" "}
-          <a
-            className="text-orange-500 transition-colors hover:text-orange-400"
-            href="https://x.com/mynameistito"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            X
-          </a>
-          )
         </p>
       </div>
     </div>

--- a/src/components/privacy-policy.tsx
+++ b/src/components/privacy-policy.tsx
@@ -8,7 +8,7 @@ export const PrivacyPolicy: React.FC = () => (
         The Fucking Privacy Policy
       </h1>
       <p className="mt-4 font-mono text-neutral-400 text-sm">
-        Last updated: December 24, 2025
+        Last updated: April 25, 2026
       </p>
 
       <div className="mt-12 space-y-8 font-sans text-neutral-300">
@@ -26,9 +26,8 @@ export const PrivacyPolicy: React.FC = () => (
             What We Collect (Spoiler: Not Your Soul)
           </h2>
           <p className="mt-4 leading-relaxed">
-            We use Umami Cloud — the privacy-respecting analytics that doesn't
-            track you like a stalker ex. It grabs only anonymized, aggregated
-            garbage like:
+            We use Cloudflare Web Analytics — privacy-respecting, no cookies, no
+            fingerprinting. It grabs only anonymized, aggregated garbage like:
           </p>
           <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-neutral-400">
             <li>Page views and how you stumble around the site</li>
@@ -68,10 +67,10 @@ export const PrivacyPolicy: React.FC = () => (
             No Cookies. No Bullshit Banners.
           </h2>
           <p className="mt-4 leading-relaxed">
-            Umami doesn't use cookies or local storage. So no "ACCEPT ALL
-            COOKIES OR WE CRY" popup. You're not being fingerprinted or tracked
-            across the internet like some normie on Google Analytics. Freedom,
-            baby.
+            Cloudflare Web Analytics doesn't use cookies or local storage. So no
+            "ACCEPT ALL COOKIES OR WE CRY" popup. You're not being fingerprinted
+            or tracked across the internet like some normie on Google Analytics.
+            Freedom, baby.
           </p>
         </section>
 
@@ -81,14 +80,13 @@ export const PrivacyPolicy: React.FC = () => (
           </h2>
           <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-neutral-400">
             <li>
-              <strong className="text-white">Umami Cloud</strong> → analytics
-              (privacy-first, no cookies, anonymized before it even hits their
-              servers)
+              <strong className="text-white">Cloudflare Web Analytics</strong> →
+              analytics (privacy-first, no cookies, data stays on Cloudflare)
             </li>
             <li>
-              <strong className="text-white">Google Fonts</strong> → pretty
-              letters (they see your IP when fetching fonts because capitalism —
-              check their policy if you care, we're not your mom)
+              <strong className="text-white">Cloudflare Fonts</strong> → pretty
+              letters (Google Fonts, but served by Cloudflare — no Google
+              tracking your eyeballs)
             </li>
           </ul>
           <p className="mt-4 leading-relaxed">
@@ -101,8 +99,9 @@ export const PrivacyPolicy: React.FC = () => (
             Data Goes Where?
           </h2>
           <p className="mt-4 leading-relaxed">
-            Umami processes it, anonymizes it, aggregates it, and doesn't sell
-            it or profile you. We don't touch it. It's their problem, not ours.
+            Cloudflare processes it, anonymizes it, aggregates it, and doesn't
+            sell it or profile you. Data stays on Cloudflare's infrastructure —
+            nowhere else.
           </p>
         </section>
 
@@ -118,14 +117,14 @@ export const PrivacyPolicy: React.FC = () => (
           <ul className="mt-4 ml-6 list-disc space-y-2 font-mono text-neutral-400">
             <li>Block analytics requests with uBlock/uMatrix/whatever</li>
             <li>
-              Cry to Umami at{" "}
+              Cry to Cloudflare at{" "}
               <a
                 className="text-orange-500 transition-colors hover:text-orange-400"
-                href="https://umami.is"
+                href="https://www.cloudflare.com/privacypolicy/"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                umami.is
+                cloudflare.com/privacypolicy
               </a>{" "}
               if you hate their vibe
             </li>

--- a/src/components/rant.tsx
+++ b/src/components/rant.tsx
@@ -37,45 +37,95 @@ export const Rant: React.FC = () => {
               BEGGING
             </span>{" "}
             you to use their{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/workers/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Workers
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/pages/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Pages
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/r2/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               R2
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/d1/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               D1
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/workers-kv/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               KV
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/durable-objects/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Durable Objects
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/cloudflare-queues/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Queues
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/workflows/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Workflows
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/workers-ai/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               AI
-            </span>
+            </a>
             ,{" "}
-            <span className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent">
+            <a
+              className="bg-gradient-to-r from-orange-500 to-orange-400 bg-clip-text font-bold text-transparent decoration-orange-500 hover:underline"
+              href="https://www.cloudflare.com/developer-platform/products/vectorize/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Vectorize
-            </span>{" "}
+            </a>{" "}
             — ALL ON ONE PLATFORM, ONE BILL, AND{" "}
             <strong className="text-white">ACTUALLY GENEROUS FREE TIERS</strong>
             .

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css" {}

--- a/src/index.html
+++ b/src/index.html
@@ -51,11 +51,6 @@
     <link rel="manifest" href="/site.webmanifest">
     <meta name="theme-color" content="#f6821f">
     <title>Just Fucking Use Cloudflare - Stop Getting Scammed</title>
-    <script
-      defer
-      src="https://cloud.umami.is/script.js"
-      data-website-id="aec2fcf2-9d6e-4539-a5b2-a7c9435c61fd"
-    ></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9582,6 +9582,7 @@ declare module "cloudflare:email" {
         prototype: EmailMessage;
         new (from: string, to: string, raw: ReadableStream | string): EmailMessage;
     };
+
     export { _EmailMessage as EmailMessage };
 }
 /**
@@ -10244,6 +10245,7 @@ interface SecretsStoreSecret {
 }
 declare module "cloudflare:sockets" {
     function _connect(address: string | SocketAddress, options?: SocketOptions): Socket;
+
     export { _connect as connect };
 }
 type MarkdownDocument = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace Umami with Cloudflare Web Analytics and update the privacy policy. Also add Cloudflare product links across the rant and comparison cards.

- **New Features**
  - Added product links: rant items now link to docs, comparison cards click through to Cloudflare product pages, and a Domains link was added to the footer.

- **Refactors**
  - Removed Umami script from `src/index.html`; updated privacy policy to Cloudflare Web Analytics and Cloudflare Fonts with a new "Last updated" date and a Cloudflare privacy link.
  - Tooling: added `src/css.d.ts` for `.css` imports, simplified `biome.jsonc`, minor formatting in `worker-configuration.d.ts`, renamed package in `package.json` to "just-fucking-use-cloudflare", and updated the dev script to use `portless` (`portless justfuckingusecloudflare vite`).

<sup>Written for commit 76277b9e849570b4e70a77b7f2cbf1cfcd37855f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Umami analytics and replace with Cloudflare Web Analytics
> - Removes the Umami script tag from [index.html](https://github.com/mynameistito/justfuckingusecloudflare/pull/61/files#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbe) and updates the [privacy policy](https://github.com/mynameistito/justfuckingusecloudflare/pull/61/files#diff-a167286d52453b70a9a412fc02436507979e31a0d0ce73341d4f6e6bfafb35b4) to reference Cloudflare Web Analytics instead.
> - Makes comparison cards clickable links to Cloudflare product pages in [comparison.tsx](https://github.com/mynameistito/justfuckingusecloudflare/pull/61/files#diff-7887a2db77a9b1bb33315dfd8de75789c93a103115afb7ab14ef330f6262dae7).
> - Converts product name highlights in [rant.tsx](https://github.com/mynameistito/justfuckingusecloudflare/pull/61/files#diff-730d917353cf3293c009590e85073c6fc8a7b715c7310aac1153fb82aefe9d43) into external links to their respective Cloudflare product pages.
> - Adds a 'Domains' link to the footer and removes personal attribution links in [footer.tsx](https://github.com/mynameistito/justfuckingusecloudflare/pull/61/files#diff-febe472312c34362d6340a54dd876572b5ef8731d37a0d895c9b6b1f2ead8a8e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76277b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->