### PR TITLE
chore: pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign issue to mynameistito
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             github.rest.issues.addAssignees({

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign issue to mynameistito
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.addAssignees({


### PR DESCRIPTION
## Summary

- Pin external GitHub Actions to full commit SHAs.
- Keep tracking comments for the latest resolved tag or branch refs.
- Refresh stale action pins to the latest tracked refs where needed.

## Verification

- Verified all scanned external action refs are SHA-pinned.
- Verified tracking comments resolve to the pinned SHA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `actions/github-script` in `.github/workflows/auto-assign.yml` to commit `ed597411d8f924073f98dfc5c65a23a2325f34cd` (`v8.0.0`) to ensure consistent and secure workflow runs. Replaces the `v8` tag with a full SHA and updates the tracking comment to `v8.0.0`.

<sup>Written for commit ae676a5b0991f9912ff4fc249c561411c0f0f5b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/justfuckingusecloudflare/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `actions/github-script` to a commit SHA in auto-assign workflow
> Replaces the floating `v8` tag with a pinned SHA (`ed597411`) in [auto-assign.yml](.github/workflows/auto-assign.yml) to prevent unexpected changes from upstream action updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae676a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->